### PR TITLE
Lambda expression for elements of function space 

### DIFF
--- a/feel/feelvf/expr.cpp
+++ b/feel/feelvf/expr.cpp
@@ -34,8 +34,8 @@ namespace Feel
 {
 namespace vf
 {
-Expr<LambdaExpr1> _e1;
-Expr<LambdaExpr2> _e2;
-Expr<LambdaExpr3> _e3;
+Expr<PlaceHolder1> _e1;
+Expr<PlaceHolder2> _e2;
+Expr<PlaceHolder3> _e3;
 }
 }

--- a/feel/feelvf/expr.hpp
+++ b/feel/feelvf/expr.hpp
@@ -53,7 +53,7 @@
 #include <feel/feelvf/exprbase.hpp>
 #include <feel/feelvf/detail/gmc.hpp>
 #include <feel/feelvf/shape.hpp>
-#include <feel/feelvf/lambda.hpp>
+#include <feel/feelvf/placeholder.hpp>
 
 namespace Feel
 {
@@ -312,7 +312,7 @@ public:
         :
         M_expr( __expr )
     {}
-    virtual ~Expr()
+    ~Expr()
     {}
 
     //@}
@@ -666,9 +666,48 @@ operator<<( std::ostream& os, Expr<ExprT> const& exprt )
 }
 
 
-extern Expr<LambdaExpr1> _e1;
-extern Expr<LambdaExpr2> _e2;
-extern Expr<LambdaExpr3> _e3;
+extern Expr<PlaceHolder1> _e1;
+extern Expr<PlaceHolder2> _e2;
+extern Expr<PlaceHolder3> _e3;
+
+template< class T >
+struct isPlaceHolder
+{
+    static constexpr int result = 0;
+};
+template<>
+struct isPlaceHolder<Expr<PlaceHolder1>>
+{
+    static constexpr int result = 1;
+};
+template<>
+struct isPlaceHolder<Expr<PlaceHolder2>>
+{
+    static constexpr int result = 2;
+};
+
+template<>
+struct isPlaceHolder<Expr<PlaceHolder3>>
+{
+    static constexpr int result = 3;
+};
+
+template<>
+struct isPlaceHolder<PlaceHolder1>
+{
+    static constexpr int result = 1;
+};
+template<>
+struct isPlaceHolder<PlaceHolder2>
+{
+    static constexpr int result = 2;
+};
+
+template<>
+struct isPlaceHolder<PlaceHolder3>
+{
+    static constexpr int result = 3;
+};
 
 /**
  * \class ExpressionOrder

--- a/feel/feelvf/geometricdata.hpp
+++ b/feel/feelvf/geometricdata.hpp
@@ -66,7 +66,7 @@ namespace Feel { namespace vf {
 
 const size_type jn = vm::JACOBIAN|vm::NORMAL;
 const size_type jkbn = vm::JACOBIAN|vm::KB|vm::NORMAL;
-const size_type jt = vm::JACOBIAN|vm::NORMAL|vm::TANGENT;
+const size_type jt = vm::JACOBIAN|vm::KB|vm::NORMAL|vm::TANGENT;
 const size_type jp = vm::JACOBIAN|vm::POINT;
 const size_type jkp = vm::KB|vm::JACOBIAN|vm::POINT;
 

--- a/feel/feelvf/ginac.hpp
+++ b/feel/feelvf/ginac.hpp
@@ -238,6 +238,21 @@ Expr< GinacEx<2> > expr( std::string const& s, std::string filename="" )
 }
 
 /**
+* @brief Create an Feel++ expression from a GiNaC expression as a string
+*
+* @param s          String containing the ginac expression and symbols
+* @param filename   Shared file
+*
+* @return Feel++ Expression
+*/
+inline
+Expr< GinacEx<2> > expr(  const char* s, std::string filename="" )
+{
+    std::pair< ex, std::vector<GiNaC::symbol> > g = GiNaC::parse(s);
+    return Expr< GinacEx<2> >(  GinacEx<2>( g.first, g.second, filename) );
+}
+
+/**
  * @brief Create an Feel++ expression from a GiNaC expression as a string
  *
  * @tparam Order     Expression order

--- a/feel/feelvf/integrate.hpp
+++ b/feel/feelvf/integrate.hpp
@@ -60,7 +60,7 @@ BOOST_PARAMETER_FUNCTION(
 {
 
     auto ret =  integrate_impl( range, quad, expr, geomap, quad1, use_tbb, use_harts, grainsize, partitioner, quadptloc );
-
+#if 0
     if ( verbose )
     {
         std::cout << " -- integrate: size(range) = " << std::distance( ret.expression().beginElement(),
@@ -69,7 +69,7 @@ BOOST_PARAMETER_FUNCTION(
         std::cout << " -- integrate: quad1 = " << ret.expression().im2().nPoints() << "\n";
         //std::cout << " -- integrate: geomap = " << geomap << "\n";
     }
-
+#endif
     return ret;
 }
 

--- a/testsuite/feeldiscr/test_lambda.cpp
+++ b/testsuite/feeldiscr/test_lambda.cpp
@@ -65,6 +65,7 @@ BOOST_AUTO_TEST_CASE( test_lambda_cst1 )
     typedef decltype(cst(1.)) t2;
     BOOST_MPL_ASSERT_MSG( (boost::is_same<t1,t2>::value), INVALID_TYPE,(decltype(I( cst(1.) )),decltype(cst(1.))));
 }
+
 BOOST_AUTO_TEST_CASE( test_lambda_cst2 )
 {
     BOOST_TEST_MESSAGE( "test_lambda_cst2" );
@@ -88,7 +89,7 @@ BOOST_AUTO_TEST_CASE( test_lambda_cst3 )
     typedef decltype(cst(1.)*cst(.5)) t2;
     BOOST_MPL_ASSERT_MSG( (boost::is_same<t1,t2>::value), INVALID_TYPE,(decltype(I( cst(1.),cst(.5) )),decltype(cst(1.)*cst(.5))));
 }
-
+#if 1
 BOOST_AUTO_TEST_CASE( test_lambda_cos )
 {
     BOOST_TEST_MESSAGE( "test_lambda_cos" );
@@ -137,6 +138,7 @@ BOOST_AUTO_TEST_CASE( test_lambda_int_cst2 )
     auto mesh = unitSquare();
     BOOST_TEST_MESSAGE( "test_lambda_int_cst2 mesh generated" );
     auto I = integrate( elements(mesh), _expr=_e1*_e2, _verbose=true );
+auto I2 = integrate( elements(mesh), _expr=idv(_e1)*idv(_e1), _verbose=true );
     auto I3 = integrate( elements(mesh), _expr=_e1*_e2*_e3, _verbose=true );
     BOOST_TEST_MESSAGE( "test_lambda_int_cst2 integral defined" );
 
@@ -149,6 +151,7 @@ BOOST_AUTO_TEST_CASE( test_lambda_int_cst2 )
     BOOST_CHECK_CLOSE( I1.evaluate()( 0, 0 ), 1, 1e-10 );
     BOOST_CHECK_CLOSE( I( cst(.5), cst(2.) ).evaluate()( 0, 0 ), 1, 1e-10 );
     BOOST_CHECK_CLOSE( I( idv(u), gradv(v)(0,0)*2.).evaluate()( 0, 0 ), 1, 1e-10 );
+    BOOST_CHECK_CLOSE( I2( u, u ).evaluate()( 0, 0 ), 0.5, 1e-10 );
     BOOST_CHECK_CLOSE( I3( cst(.5), cst(2.), cst(1.0) ).evaluate()( 0, 0 ), 1, 1e-10 );
     BOOST_CHECK_CLOSE( I3( cst(2.)*idv(u), gradv(v)*trans(gradv(v)), idv(w)/(cst(2.0)*(Px()+1)) ).evaluate()( 0, 0 ), 1, 1e-10 );
 
@@ -251,6 +254,6 @@ BOOST_AUTO_TEST_CASE( test_lambda_div )
     BOOST_CHECK_CLOSE( integrate_lambda, I_lambda_sigma(idv(T)).evaluate()( 0, 0 ) , 1e-10 );
 
 }
-
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
allow lambda expression such that

```
auto a = form2(Xh,Xh)
a=  integrate( ... _expr=idv(_e1) *gradv(_e2) );
```

however this currently implies that we change the semantic with respect to
operators which means copying the function each time we use one of these
keywords instead of storing the reference.
Let's see if we manage to fix that. That is the reason why it is in a branch