### PR TITLE
Feature/hdf5 grp

### DIFF
--- a/feel/feelcore/hdf5.hpp
+++ b/feel/feelcore/hdf5.hpp
@@ -23,10 +23,11 @@
 */
 /**
    \file hdf5.hpp
-  @author Radu Popescu <radu.popescu@epfl.ch> (LifeV)
+   \author Radu Popescu <radu.popescu@epfl.ch> (LifeV)
    \author Christophe Prud'homme <christophe.prudhomme@feelpp.org> (adaptation from LifeV to Feel++)
    \author Benjamin Vanthong <benjamin.vanthong@gmail.com>
-   \date 2013-10-16
+   \author Guillaume Dollé <gdolle@unistra.fr>
+   \date 2015-10-01
  */
 #ifndef FEELPP_HDF5_HPP
 #define FEELPP_HDF5_HPP
@@ -47,6 +48,11 @@
 
 namespace Feel
 {
+
+    enum H5Gopen_flags{
+        CREATE
+    };
+
 
 /*!
   @brief Convenience wrapper for the C interface of the HDF5 library
@@ -89,8 +95,8 @@ public:
      * \param existing boolean flag indicating whether the file exists already
      *        or not. If it exists, data is appended
      */
-    HDF5 (const std::string& fileName, const comm_type& comm,
-            const bool& existing = false);
+    HDF5( const std::string& fileName, const comm_type& comm,
+          const bool& existing = false );
 
     //! Empty destructor
     virtual ~HDF5() {}
@@ -98,7 +104,14 @@ public:
 
     //! @name Public Methods
     //@{
-    //! Open
+
+    //! Check if group exist.
+    /*!
+     * \param groupName full path to the group under root.
+     */
+    bool groupExist( const std::string& groupName );
+
+    //! Create or open a file.
     /*!
      * Create a file or open an existing file
      * \param fileName the name of the HDF5 file to be used
@@ -106,14 +119,35 @@ public:
      * \param existing boolean flag indicating whether the file exists already
      *        or not. If it exists, data is appended
      */
-    void openFile (const std::string& fileName, const comm_type& comm,
-                   const bool& existing);
+    void openFile( const std::string& fileName, const comm_type& comm,
+                   const bool& existing );
 
     //! Create a new group
     /*!
      * Create a new group in the open file
      */
-    void createGroup (const std::string& tableName);
+    void createGroup( const std::string& tableName );
+
+    //! Open group
+    /*!
+     * Open an existing group.
+     * \param groupName Name of the group.
+     * \param createIfNotExist Create all groups which does not exist in
+     *        the given group path (default: true).
+     */
+    void openGroup( const std::string& groupName,
+                    const bool& createIfNotExist = true );
+
+    //! Open groups
+    /*!
+     * Open recursively all existing group from the given group name.
+     * \param groupName Name of the group.
+     * \param createIfNotExist Create all groups which does not exist in
+     *        the given group path (default: true).
+     */
+    void openGroups( const std::string& groupName,
+                     const bool& createIfNotExist = true );
+
     //! Create a new table
     /*!
      * Create a new table in the open file
@@ -124,11 +158,26 @@ public:
      * \param tableDimensions array of hsize_t of size 2 which holds the
      *        dimensions of the table
      */
-    void createTable (const std::string& tableName, hid_t& fileDataType,
-                      hsize_t tableDimensions[]);
+    void createTable( const std::string& tableName,
+                      hid_t& fileDataType,
+                      hsize_t tableDimensions[] );
 
-    void createTable (const std::string& GroupName, const std::string& tableName, hid_t& fileDataType,
-                             hsize_t tableDimensions[], const bool& existing);
+    //! Create a new table
+    /*!
+     * Create a new table in the open file under the given group.
+     * \param groupName A string containing the group name.
+     * \param tableName A string containing the table name.
+     * \param fileDataType Data type that is to be used in the HDF5 container
+     *        should be a standard HDF5 type, not a machine native type;
+     *        Consult HDF5 documentation for more information.
+     * \param tableDimensions Array of hsize_t of size 2 which holds the
+     *        dimensions of the table.
+     */
+    void createTable( const std::string& GroupName,
+                      const std::string& tableName,
+                      hid_t& fileDataType,
+                      hsize_t tableDimensions[],
+                      const bool& existing );
 
     //! Open a new table
     /*!
@@ -137,7 +186,8 @@ public:
      * \param tableDimensions array of hsize_t of size 2 which will hold the
      *        dimensions of the table (output parameter)
      */
-    void openTable (const std::string& tableName, hsize_t tableDimensions[]);
+    void openTable( const std::string& tableName, hsize_t tableDimensions[] );
+
     //! Write
     /*!
      * \param tableName a string containing the table name
@@ -150,10 +200,13 @@ public:
      * \param buffer pointer to a memory region containing the data to be
      *        written
      */
-    void write (const std::string& tableName,
-                hid_t& memDataType, hsize_t currentCount[],
-                hsize_t currentOffset[], void* buffer);
-    //! Write
+    void write( const std::string& tableName,
+                hid_t& memDataType,
+                hsize_t currentCount[],
+                hsize_t currentOffset[],
+                void* buffer );
+
+    //! Read
     /*!
      * \param tableName a string containing the table name
      * \param memDataType the type (described as an HDF5 machine native type)
@@ -165,20 +218,36 @@ public:
      * \param buffer pointer to a memory region that represents the destination
      *        of the read operation
      */
-    void read (const std::string& tableName,
-               hid_t& memDataType, hsize_t currentCount[],
-               hsize_t currentOffset[], void* buffer);
-    //! Write
-    /*!
-     * \param tableName a string containing the table name
+    void read( const std::string& tableName,
+               hid_t& memDataType,
+               hsize_t currentCount[],
+               hsize_t currentOffset[],
+               void* buffer );
+
+    //! Close an open group.
+    /*
+     * \param groupName A string containing the group name.
      */
-    void closeGroup (const std::string& groupName);
-    void closeTable (const std::string& tableName);
+    void closeGroup( const std::string& groupName );
+
+    //! Close recursively open groups.
+    /*
+     * \param groupName A string containing the group name.
+     */
+    void closeGroups( const std::string& groupName );a
+
+    //! Close open table.
+    /*!
+     * \param tableName A string containing the table name.
+     */
+    void closeTable( const std::string& tableName );
+
     //! Close an open file
     /*!
-     * Call this when finished operating with a file
+     * Call this when finished operating with a file.
      */
     void closeFile();
+
     //@}
 
 private:

--- a/feel/feelcore/hdf5.hpp
+++ b/feel/feelcore/hdf5.hpp
@@ -48,12 +48,6 @@
 
 namespace Feel
 {
-
-    enum H5Gopen_flags{
-        CREATE
-    };
-
-
 /*!
   @brief Convenience wrapper for the C interface of the HDF5 library
   @author Radu Popescu <radu.popescu@epfl.ch>
@@ -234,7 +228,7 @@ public:
     /*
      * \param groupName A string containing the group name.
      */
-    void closeGroups( const std::string& groupName );a
+    void closeGroups( const std::string& groupName );
 
     //! Close open table.
     /*!

--- a/testsuite/feelcore/test_hdf5.cpp
+++ b/testsuite/feelcore/test_hdf5.cpp
@@ -241,6 +241,79 @@ void run2()
     delete[] offsetElt;
 }
 
+// Test groups.
+void run3()
+{
+    using namespace Feel;
+
+    auto comm = Environment::worldComm();
+    HDF5 h5;
+
+    bool isLoad = false;
+    h5.openFile( "groups.h5", comm, isLoad );
+    isLoad = true;
+
+    h5.openGroups( "class_1/sub_1" );
+    h5.closeGroups( "class_1/sub_1" );
+
+    h5.openGroups( "class_2" );
+    h5.closeGroups( "class_2" );
+
+    // Check slash.
+    h5.openGroups( "/class_3" );
+    h5.closeGroups( "/class_3" );
+
+    h5.openGroups( "/class_4/" );
+    h5.closeGroups( "/class_4/" );
+
+    h5.openGroups( "class_5/" );
+    h5.closeGroups( "class_5/" );
+
+    // Check slash with sub.
+    h5.openGroups( "class_6/sub_6" );
+    h5.closeGroups( "class_6/sub_6" );
+
+    h5.openGroups( "/class_7/sub_7" );
+    h5.closeGroups( "/class_7/sub_7" );
+
+    h5.openGroups( "/class_8/sub_8/" );
+    h5.closeGroups( "/class_8/sub_8/" );
+
+    h5.openGroups( "class_9/sub_9/" );
+    h5.closeGroups( "class_9/sub_9/" );
+
+    // Check reopen group.
+    h5.openGroups( "class_1" );
+    h5.closeGroups( "class_1" );
+
+    // Check create when top group exist.
+    h5.openGroups( "class_1/sub_2/subsub_1" );
+    h5.closeGroups( "class_1/sub_2/subsub_1" );
+
+    h5.closeFile();
+
+
+    // Check that groups exist in the file.
+    h5.openFile( "groups.h5", comm, isLoad );
+
+    BOOST_CHECK( h5.groupExist( "/class_1" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_2" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_3" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_4" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_5" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_6" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_7" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_8" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_6/sub_6" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_7/sub_7" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_8/sub_8" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_9/sub_9" ) == true );
+    BOOST_CHECK( h5.groupExist( "/class_1/sub_2/subsub_1" ) == true );
+
+    h5.closeFile();
+}
+
+
 } // namespace test_hdf5
 
 FEELPP_ENVIRONMENT_NO_OPTIONS
@@ -251,6 +324,7 @@ BOOST_AUTO_TEST_CASE( hdf5 )
 {
     test_hdf5::run1();
     test_hdf5::run2();
+    test_hdf5::run3();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
* Add new function `openGroups`, `closeGroups` to open/close recursively groups in a "matlab" way.
   e.g:

 ```cpp
openGroups("a/b/c") // Create or open groups a, b and c.
closeGroups("a/b/c") // Close groups  c, b and a.
```

* Add function `groupExist` to check if group exist in an loaded HDF5 file.
* Add new feelts test in the testsuite.
* Fix spacing and typo to respect Feel++ coding style.