### PR TITLE
Correction of testsuite fails from #586

### DIFF
--- a/testsuite/feelpoly/test_immultiscale.cfg
+++ b/testsuite/feelpoly/test_immultiscale.cfg
@@ -1,3 +1,3 @@
-[Feel.msi]
+[msi]
+level=8
 pixelsize=8.9e-3
-level=4

--- a/testsuite/feelpoly/test_immultiscale.cfg
+++ b/testsuite/feelpoly/test_immultiscale.cfg
@@ -1,3 +1,4 @@
 [msi]
+
 level=8
 pixelsize=8.9e-3

--- a/testsuite/feelpoly/test_immultiscale.cpp
+++ b/testsuite/feelpoly/test_immultiscale.cpp
@@ -48,8 +48,8 @@ inline
 AboutData
 makeAbout()
 {
-    AboutData about( "test_integrateQuadra" ,
-                     "test_integrateQuadra" ,
+    AboutData about( "test_immultiscale" ,
+                     "test_immultiscale" ,
                      "0.2",
                      "test integrate Quadra",
                      Feel::AboutData::License_GPL,
@@ -149,7 +149,7 @@ public:
 
 //#if defined(USE_BOOST_TEST)
 FEELPP_ENVIRONMENT_WITH_OPTIONS( makeAbout(), feel_options() );
-BOOST_AUTO_TEST_SUITE( integrQuadra_suite )
+BOOST_AUTO_TEST_SUITE( immultiscale_suite )
 BOOST_AUTO_TEST_CASE( im1d_test1 )
 {
     TestImQK<1,1, double> t1( 2.0, one<double> );

--- a/testsuite/feelpoly/test_immultiscale.cpp
+++ b/testsuite/feelpoly/test_immultiscale.cpp
@@ -50,7 +50,7 @@ makeAbout()
 {
     AboutData about( "test_immultiscale" ,
                      "test_immultiscale" ,
-                     "0.2",
+                     "8.9e-3",
                      "test integrate Quadra",
                      Feel::AboutData::License_GPL,
                      "Copyright (c) 2015 Feel++ Consortium" );


### PR DESCRIPTION
From #586 
The config file associated to the testsuite wasn't taken into account.
And so, the msi level value was the one by default ( i.e 0 ), that's why the integral estimation accuracy comparison have failed in each subtest.