### PR TITLE
Feature/issue1052

### DIFF
--- a/feel/feelmodels/modelmaterials.cpp
+++ b/feel/feelmodels/modelmaterials.cpp
@@ -41,8 +41,13 @@ ModelMaterial::ModelMaterial( std::string const& name, pt::ptree const& p, World
     M_p( p ),
     M_directoryLibExpr( directoryLibExpr )
 {
-    if( boost::optional<std::string> itphyisic = p.get_optional<std::string>( "physics" ) )
-        M_physics = *itphyisic;
+    if( auto physics = p.get_child_optional("physics") )
+    {
+        for( auto const& item : p.get_child("physics") )
+            M_physics.insert(item.second.template get_value<std::string>());
+        if( M_physics.empty() )
+            M_physics.insert(p.get<std::string>("physics") );
+    }
 
     std::set<std::string> matProperties = { "rho","mu","Cp","Cv","Tref","beta",
                                             "k11","k12","k13","k22","k23","k33",

--- a/feel/feelmodels/modelmaterials.hpp
+++ b/feel/feelmodels/modelmaterials.hpp
@@ -53,14 +53,16 @@ struct FEELPP_EXPORT ModelMaterial
                    std::string const& directoryLibExpr = "" );
 
     std::string const& name() const { return M_name; }
-    std::string const& physics() const { return M_physics; }
+    std::set<std::string> const& physics() const { return M_physics; }
+    std::string const physic() const { return M_physics.empty() ? "" : *(M_physics.begin()); }
     /*! Set Name
      */
     void setName( std::string const& name ) { M_name = name; }
 
     void setDirectoryLibExpr( std::string const& directoryLibExpr ) { M_directoryLibExpr = directoryLibExpr; }
 
-    void setPhysics( std::string const s) { M_physics = s; }
+    void setPhysics( std::set<std::string> const s) { M_physics = s; }
+    void addPhysics( std::string const s) { M_physics.insert( s ); }
 
     void setProperty( std::string const& property, pt::ptree const& p );
     void setProperty( std::string const& property, double val );
@@ -73,6 +75,9 @@ struct FEELPP_EXPORT ModelMaterial
     expr_scalar_type const& propertyExprScalar( std::string const& prop ) const;
     expr_vectorial2_type const& propertyExprVectorial2( std::string const& prop ) const;
     expr_vectorial3_type const& propertyExprVectorial3( std::string const& prop ) const;
+
+    bool hasPhysics() const { return !M_physics.empty(); }
+    bool hasPhysics( std::string physic ) const { return M_physics.find(physic) != M_physics.end(); }
 
     /*! Material mass density
      */
@@ -160,7 +165,7 @@ struct FEELPP_EXPORT ModelMaterial
     /**
      *
      */
-    std::string getString( std::string const& key ) {
+    std::string getString( std::string const& key ) const {
         try { return M_p.get<std::string>( key ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -171,7 +176,7 @@ struct FEELPP_EXPORT ModelMaterial
     /**
      *
      */
-    int getInt( std::string const& key ) {
+    int getInt( std::string const& key ) const {
         try { return M_p.get<int>( key ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -182,7 +187,7 @@ struct FEELPP_EXPORT ModelMaterial
     /**
      *
      */
-    double getDouble( std::string const& key ) {
+    double getDouble( std::string const& key ) const {
         try { return M_p.get<double>( key ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -192,7 +197,7 @@ struct FEELPP_EXPORT ModelMaterial
     /**
      *
      */
-    Expr<GinacEx<2> > getScalar( std::string const& key ) {
+    Expr<GinacEx<2> > getScalar( std::string const& key ) const {
         try { return expr( M_p.get<std::string>( key ) ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -203,7 +208,7 @@ struct FEELPP_EXPORT ModelMaterial
     /**
      *
      */
-    Expr<GinacEx<2> > getScalar( std::string const& key, std::map<std::string,double> const& params ) {
+    Expr<GinacEx<2> > getScalar( std::string const& key, std::map<std::string,double> const& params ) const {
         try { return expr( M_p.get<std::string>( key ), params ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -215,7 +220,7 @@ struct FEELPP_EXPORT ModelMaterial
      *
      */
     template<typename ExprT> Expr<GinacExVF<ExprT> > getScalar( std::string const& key,
-                                                                std::string const& sym, ExprT e ) {
+                                                                std::string const& sym, ExprT e ) const {
         try { return expr( M_p.get<std::string>( key ), sym, e ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -228,7 +233,7 @@ struct FEELPP_EXPORT ModelMaterial
      */
     template<typename ExprT> Expr<GinacExVF<ExprT> > getScalar( std::string const& key,
                                                                 std::initializer_list<std::string> const& sym,
-                                                                std::initializer_list<ExprT> e ) {
+                                                                std::initializer_list<ExprT> e ) const {
         try { return expr( M_p.get<std::string>( key ), sym, e ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -241,7 +246,7 @@ struct FEELPP_EXPORT ModelMaterial
      */
     template<typename ExprT> Expr<GinacExVF<ExprT> > getScalar( std::string const& key,
                                                                 std::vector<std::string> const& sym,
-                                                                std::vector<ExprT> e ) {
+                                                                std::vector<ExprT> e ) const {
         try { return expr( M_p.get<std::string>( key ), sym, e ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -255,7 +260,7 @@ struct FEELPP_EXPORT ModelMaterial
     template<typename ExprT> Expr<GinacExVF<ExprT> > getScalar( std::string const& key,
                                                                 std::initializer_list<std::string> const& sym,
                                                                 std::initializer_list<ExprT> e,
-                                                                std::map<std::string, double> params ) {
+                                                                std::map<std::string, double> params ) const {
         try {
             auto ex = expr( M_p.get<std::string>( key ), sym, e );
             ex.setParameterValues( params );
@@ -266,7 +271,7 @@ struct FEELPP_EXPORT ModelMaterial
             exit(1);
         }
     }
-    template<int T> Expr<GinacMatrix<T,1,2> > getVector( std::string const& key ) {
+    template<int T> Expr<GinacMatrix<T,1,2> > getVector( std::string const& key ) const {
         try { return expr<T,1>( M_p.get<std::string>( key ) ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -274,7 +279,7 @@ struct FEELPP_EXPORT ModelMaterial
         }
     }
     template<int T> Expr<GinacMatrix<T,1,2> > getVector( std::string const& key,
-                                                         std::pair<std::string,double> const& params ) {
+                                                         std::pair<std::string,double> const& params ) const {
         try { return expr<T,1>( M_p.get<std::string>( key ), params ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -282,7 +287,7 @@ struct FEELPP_EXPORT ModelMaterial
         }
     }
     template<int T> Expr<GinacMatrix<T,1,2> > getVector( std::string const& key,
-                                                         std::map<std::string,double> const& params ) {
+                                                         std::map<std::string,double> const& params ) const {
         try { return expr<T,1>( M_p.get<std::string>( key ), params ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -292,7 +297,7 @@ struct FEELPP_EXPORT ModelMaterial
     // template<int T, typename ExprT> Expr<GinacMatrixVF<ExprT> > getVector( std::string const& key, std::string const& sym, ExprT e );
     // template<int T, typename ExprT> Expr<GinacMatrix<T,1,2> > getVector( std::string const& key, std::initializer_list<std::string> const& sym, std::initializer_list<ExprT> e );
     // template<int T, typename ExprT> Expr<GinacMatrix<T,1,2> > getVector( std::string const& key, std::vector<std::string> const& sym, std::vector<ExprT> e );
-    template<int T1, int T2=T1> Expr<GinacMatrix<T1,T2,2> > getMatrix( std::string const& key ) {
+    template<int T1, int T2=T1> Expr<GinacMatrix<T1,T2,2> > getMatrix( std::string const& key ) const {
         try { return expr<T1,T2>( M_p.get<std::string>( key ) ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -300,7 +305,7 @@ struct FEELPP_EXPORT ModelMaterial
         }
     }
     template<int T1, int T2=T1> Expr<GinacMatrix<T1,T2,2> > getMatrix( std::string const& key,
-                                                                       std::pair<std::string,double> const& params ) {
+                                                                       std::pair<std::string,double> const& params ) const {
         try { return expr<T1,T2>( M_p.get<std::string>( key ), params ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -308,7 +313,7 @@ struct FEELPP_EXPORT ModelMaterial
         }
     }
     template<int T1, int T2=T1> Expr<GinacMatrix<T1,T2,2> > getMatrix( std::string const& key,
-                                                                       std::map<std::string,double> const& params ) {
+                                                                       std::map<std::string,double> const& params ) const {
         try { return expr<T1,T2>( M_p.get<std::string>( key ), params ); }
         catch( pt::ptree_error e ) {
             cerr << "key " << key << ": " << e.what() << std::endl;
@@ -329,7 +334,7 @@ private:
     //! mat propeteries
     std::map<std::string, mat_property_expr_type > M_materialProperties;
     //! material physics
-    std::string M_physics;
+    std::set<std::string> M_physics;
 };
 
 std::ostream& operator<<( std::ostream& os, ModelMaterial const& m );
@@ -359,6 +364,18 @@ public:
             return it->second;
 
         }
+
+    /** return all the materials which physic is physic
+     *
+     */
+    std::map<std::string,ModelMaterial> materialWithPhysic(std::string physic) const
+    {
+        std::map<std::string,ModelMaterial> mat;
+        std::copy_if(this->begin(),this->end(),std::inserter(mat,mat.begin()),
+                     [physic](std::pair<std::string,ModelMaterial> const& mp)
+                     { return mp.second.hasPhysics(physic); } );
+        return mat;
+    }
 
     void setDirectoryLibExpr( std::string const& directoryLibExpr ) { M_directoryLibExpr = directoryLibExpr; }
 

--- a/testsuite/feelmodels/test.feelpp
+++ b/testsuite/feelmodels/test.feelpp
@@ -23,6 +23,20 @@
         "fluid":
         {
             "name":"fluid",
+            "physics": "electro",
+            "rho": "1", // density
+            "eta": "0.001", // dynamic_viscosity
+            "mu": "{1,t}:t",
+            "nu": "{1,2,x*y}:x:y:z",
+            "chi": "{1,2,x,y}:x:y",
+            "xhi": "{1,2,3,4,5,6,7,8,t}:t",
+            "f" : "2*g:g",
+            "h" : "2*g+t:g:t"
+        },
+	"copper":
+        {
+            "name":"copper",
+            "physics":["electro","thermo"],
             "rho": "1", // density
             "eta": "0.001", // dynamic_viscosity
             "mu": "{1,t}:t",

--- a/testsuite/feelmodels/test_modelproperties.cpp
+++ b/testsuite/feelmodels/test_modelproperties.cpp
@@ -44,6 +44,7 @@ int main( int argc, char** argv )
     {
         Feel::cout << "properties for " << matPair.first << std::endl;
         auto mat = matPair.second;
+        auto physics = mat.physics();
         auto name = mat.getString("name");
         auto rhoInt = mat.getInt("rho");
         auto etaDouble = mat.getDouble("eta");
@@ -65,6 +66,9 @@ int main( int argc, char** argv )
         auto xhiMap = mat.getMatrix<3,3>( "xhi", {{"t",3.}});
 
         Feel::cout << "\t" << name << std::endl;
+        Feel::cout << "\thas " << physics.size() << " physics:" << std::endl;
+        for( auto const& p : physics )
+            Feel::cout << "\t\t" << p << std::endl;
         Feel::cout << "\t" << rhoInt << std::endl;
         Feel::cout << "\t" << etaDouble << std::endl;
         Feel::cout << "\t" << rho << std::endl;
@@ -76,6 +80,9 @@ int main( int argc, char** argv )
         Feel::cout << "\t" << xhiPair << std::endl;
         Feel::cout << "\t" << xhiMap << std::endl;
     }
+
+    Feel::cout << mats.materialWithPhysic("electro").size() << " materials with electro physic" << std::endl;
+    Feel::cout << mats.materialWithPhysic("thermo").size() << " materials with thermo physic" << std::endl;
 
     auto param = model_props.parameters();
     for ( auto const& pp : param )

--- a/toolboxes/feel/feelmodels/fluid/dynamicviscositymodel.hpp
+++ b/toolboxes/feel/feelmodels/fluid/dynamicviscositymodel.hpp
@@ -101,7 +101,7 @@ public :
                 if ( eltMarkersInMesh.find( matmarker ) == eltMarkersInMesh.end() )
                     continue;
                 auto const& mat = m.second;
-                std::string matphysics = ( mat.physics().empty() )? "fluid" : mat.physics();
+                std::string matphysics = ( mat.physics().empty() )? "fluid" : mat.physic();
                 if ( ( matphysics != "fluid" ) && ( matphysics != "aerothermal" ) )
                     continue;
                 M_markers.insert( matmarker );

--- a/toolboxes/feel/feelmodels/thermodyn/thermalpropertiesdescription.hpp
+++ b/toolboxes/feel/feelmodels/thermodyn/thermalpropertiesdescription.hpp
@@ -51,7 +51,7 @@ namespace FeelModels
                     if ( eltMarkersInMesh.find( matmarker ) == eltMarkersInMesh.end() )
                         continue;
                     auto const& mat = m.second;
-                    std::string matphysics = ( mat.physics().empty() )? "heat-transfert" : mat.physics();
+                    std::string matphysics = ( mat.physics().empty() )? "heat-transfert" : mat.physic();
                     if ( ( matphysics != "heat-transfert" ) && ( matphysics != "aerothermal" ) && ( matphysics != "thermo-electric" ) )
                         continue;
                     M_markers.insert( matmarker );

--- a/toolboxes/feel/feelmodels/thermoelectric/electricpropertiesdescription.hpp
+++ b/toolboxes/feel/feelmodels/thermoelectric/electricpropertiesdescription.hpp
@@ -50,7 +50,7 @@ namespace FeelModels
                     if ( eltMarkersInMesh.find( matmarker ) == eltMarkersInMesh.end() )
                         continue;
                     auto const& mat = m.second;
-                    std::string matphysics = ( mat.physics().empty() )? "electric" : mat.physics();
+                    std::string matphysics = ( mat.physics().empty() )? "electric" : mat.physic();
                     if ( ( matphysics != "electric" ) && ( matphysics != "thermo-electric" ) )
                         continue;
                     M_markers.insert( matmarker );


### PR DESCRIPTION
- change `M_physics` to `std::set`
- add methods:
  - `physics()`: return the set of physics
  - `physic()`: return the first physic or "" if void
  - `setPhysics(std::set<std::string>)`: set the set of physics
  - `addPhysics(std::string)`: add one physic
  - `hasPhysics()`: return if the material has one or more physics
  - `hasPhysics(std::string p)`: return if the material has the physic `p`
  - `materialWithPhysics(std::string p)`: return a sub map of materials with physic `p`
- add const specifiers for getter methods
- change toolboxes to use first physic