### PR TITLE
add modeloutput class to manage crb output

### DIFF
--- a/feel/feelcore/environment.cpp
+++ b/feel/feelcore/environment.cpp
@@ -2211,7 +2211,6 @@ Environment::expand( std::string const& expr )
     boost::replace_all( res, "${datadir}", dataDir );
     boost::replace_all( res, "${exprdbdir}", exprdbDir );
     boost::replace_all( res, "${h}", std::to_string(doption("gmsh.hsize") ) );
-    boost::replace_all( res, "${testsuite_srcdir}", topSrcDir + "/testsuite/" );
 
     boost::replace_all( res, "$feelpp_srcdir", topSrcDir );
     boost::replace_all( res, "$feelpp_builddir", topBuildDir );
@@ -2225,7 +2224,6 @@ Environment::expand( std::string const& expr )
     boost::replace_all( res, "$datadir", dataDir );
     boost::replace_all( res, "$exprdbdir", exprdbDir );
     boost::replace_all( res, "$h", std::to_string(doption("gmsh.hsize") ) );
-    boost::replace_all( res, "$testsuite_srcdir", topSrcDir + "/testsuite/" );
 
 
     typedef std::vector< std::string > split_vector_type;

--- a/feel/feelcore/environment.cpp
+++ b/feel/feelcore/environment.cpp
@@ -2211,6 +2211,7 @@ Environment::expand( std::string const& expr )
     boost::replace_all( res, "${datadir}", dataDir );
     boost::replace_all( res, "${exprdbdir}", exprdbDir );
     boost::replace_all( res, "${h}", std::to_string(doption("gmsh.hsize") ) );
+    boost::replace_all( res, "${testsuite_srcdir}", topSrcDir + "/testsuite/" );
 
     boost::replace_all( res, "$feelpp_srcdir", topSrcDir );
     boost::replace_all( res, "$feelpp_builddir", topBuildDir );
@@ -2224,6 +2225,7 @@ Environment::expand( std::string const& expr )
     boost::replace_all( res, "$datadir", dataDir );
     boost::replace_all( res, "$exprdbdir", exprdbDir );
     boost::replace_all( res, "$h", std::to_string(doption("gmsh.hsize") ) );
+    boost::replace_all( res, "$testsuite_srcdir", topSrcDir + "/testsuite/" );
 
 
     typedef std::vector< std::string > split_vector_type;

--- a/feel/feelmodels/CMakeLists.txt
+++ b/feel/feelmodels/CMakeLists.txt
@@ -23,7 +23,7 @@
 #
 
 SET( SRC
-  modelproperties.cpp modelparameters.cpp modelmaterials.cpp modelpostprocess.cpp modelfunctions.cpp
+  modelproperties.cpp modelparameters.cpp modelmaterials.cpp modelpostprocess.cpp modelfunctions.cpp modeloutputs.cpp
   )
 
 file(GLOB HDR RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.hpp  )

--- a/feel/feelmodels/modeloutputs.cpp
+++ b/feel/feelmodels/modeloutputs.cpp
@@ -1,0 +1,134 @@
+/* -*- mode: c++; coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; show-trailing-whitespace: t  -*-
+ 
+ This file is part of the Feel++ library
+ 
+ Author(s): Christophe Prud'homme <christophe.prudhomme@feelpp.org>
+ Date: 16 Mar 2015
+ 
+ Copyright (C) 2015 Feel++ Consortium
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include <iostream>
+#include <boost/property_tree/json_parser.hpp>
+
+#include <feel/feelmodels/modeloutputs.hpp>
+
+namespace Feel {
+
+ModelOutput::ModelOutput( WorldComm const& worldComm )
+    :
+    M_worldComm( &worldComm )
+{}
+
+ModelOutput::ModelOutput( std::string name, pt::ptree const& p, WorldComm const& worldComm, std::string const& directoryLibExpr )
+    :
+    M_worldComm( &worldComm ),
+    M_p( p ),
+    M_directoryLibExpr( directoryLibExpr ),
+    M_name( name )
+{
+    try {
+        M_type  = M_p.get<std::string>( "type"  );
+    }
+    catch ( pt::ptree_bad_path& e )
+    {
+        if ( Environment::isMasterRank() )
+            std::cout << "Missing type entry in output " << M_name << "\n";
+    }
+    if( auto range = p.get_child_optional("range") )
+    {
+        for( auto const& item : p.get_child("range") )
+            M_range.insert(item.second.template get_value<std::string>());
+        if( M_range.empty() )
+            M_range.insert(p.get<std::string>("range") );
+    }
+    else
+    {
+        LOG(WARNING) << "Output " << M_name << " does not have any range\n";
+        std::cout << "Output " << M_name << " does not have any range\n";
+    }
+    if( auto t = p.get_optional<int>("topodim") )
+    {
+        M_dim = *t;
+    }
+    else
+    {
+        LOG(WARNING) << "Output " << M_name << " does not have any dimension\n";
+    }
+}
+
+std::ostream& operator<<( std::ostream& os, ModelOutput const& o )
+{
+    os << "Output " << o.name()
+       << "[ type: " << o.type()
+       << ", dim: " << o.dim()
+       << ", range: [";
+    for( auto const& r : o.range() )
+    {
+        os << r << " ";
+    }
+    os << "]]" << std::endl;
+    return os;
+}
+
+ModelOutputs::ModelOutputs( WorldComm const& worldComm )
+    :
+    M_worldComm( &worldComm )
+{}
+
+ModelOutputs::ModelOutputs( pt::ptree const& p, WorldComm const& worldComm )
+    :
+    M_worldComm( &worldComm ),
+    M_p( p )
+{
+    setup();
+}
+
+ModelOutput
+ModelOutputs::loadOutput( std::string const& s, std::string name )
+{
+    pt::ptree p;
+    pt::read_json( s, p );
+    return this->getOutput( p, name );
+}
+
+void
+ModelOutputs::setup()
+{
+    for( auto const& v : M_p )
+    {
+        LOG(INFO) << "Output :" << v.first  << "\n";
+        if ( auto fname = v.second.get_optional<std::string>("filename") )
+        {
+            LOG(INFO) << "  - filename = " << Environment::expand( fname.get() ) << std::endl;
+            this->insert( std::make_pair( v.first, this->loadOutput( Environment::expand( fname.get() ), v.first ) ) );
+        }
+        else
+        {
+            this->insert( std::make_pair( v.first, this->getOutput( v.second, v.first ) ) );
+        }
+    }
+}
+
+ModelOutput
+ModelOutputs::getOutput( pt::ptree const& v, std::string name )
+{
+    ModelOutput o( name, v, *M_worldComm, M_directoryLibExpr );
+    LOG(INFO) << "adding output " << o;
+    return o;
+}
+
+} // namespace Feel

--- a/feel/feelmodels/modeloutputs.cpp
+++ b/feel/feelmodels/modeloutputs.cpp
@@ -68,6 +68,15 @@ ModelOutput::ModelOutput( std::string name, pt::ptree const& p, WorldComm const&
     }
 }
 
+std::string ModelOutput::getString( std::string const& key ) const
+{
+    try { return M_p.get<std::string>( key ); }
+    catch( pt::ptree_error e ) {
+        LOG(ERROR) << "output " << M_name << ": key " << key << ": " << e.what() << std::endl;
+        exit(1);
+    }
+}
+
 std::ostream& operator<<( std::ostream& os, ModelOutput const& o )
 {
     os << "Output " << o.name()
@@ -96,7 +105,7 @@ ModelOutputs::ModelOutputs( pt::ptree const& p, WorldComm const& worldComm )
 }
 
 ModelOutput
-ModelOutputs::loadOutput( std::string const& s, std::string name )
+ModelOutputs::loadOutput( std::string const& s, std::string const& name )
 {
     pt::ptree p;
     pt::read_json( s, p );
@@ -122,7 +131,7 @@ ModelOutputs::setup()
 }
 
 ModelOutput
-ModelOutputs::getOutput( pt::ptree const& v, std::string name )
+ModelOutputs::getOutput( pt::ptree const& v, std::string const& name )
 {
     ModelOutput o( name, v, *M_worldComm, M_directoryLibExpr );
     LOG(INFO) << "adding output " << o;

--- a/feel/feelmodels/modeloutputs.cpp
+++ b/feel/feelmodels/modeloutputs.cpp
@@ -45,8 +45,7 @@ ModelOutput::ModelOutput( std::string name, pt::ptree const& p, WorldComm const&
     }
     catch ( pt::ptree_bad_path& e )
     {
-        if ( Environment::isMasterRank() )
-            std::cout << "Missing type entry in output " << M_name << "\n";
+        LOG(WARNING) << "Missing type entry in output " << M_name << "\n";
     }
     if( auto range = p.get_child_optional("range") )
     {
@@ -58,7 +57,6 @@ ModelOutput::ModelOutput( std::string name, pt::ptree const& p, WorldComm const&
     else
     {
         LOG(WARNING) << "Output " << M_name << " does not have any range\n";
-        std::cout << "Output " << M_name << " does not have any range\n";
     }
     if( auto t = p.get_optional<int>("topodim") )
     {

--- a/feel/feelmodels/modeloutputs.hpp
+++ b/feel/feelmodels/modeloutputs.hpp
@@ -1,0 +1,95 @@
+/* -*- mode: c++; coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; show-trailing-whitespace: t  -*-
+
+ This file is part of the Feel++ library
+
+ Author(s): Christophe Prud'homme <christophe.prudhomme@feelpp.org>
+ Date: 16 Mar 2015
+
+ Copyright (C) 2015 Feel++ Consortium
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef FEELPP_MODELOUTPUTS_HPP
+#define FEELPP_MODELOUTPUTS_HPP 1
+
+#include <boost/property_tree/ptree.hpp>
+#include <feel/feelvf/ginac.hpp>
+
+namespace Feel {
+
+namespace pt =  boost::property_tree;
+
+class FEELPP_EXPORT ModelOutput
+{
+  public:
+    ModelOutput( WorldComm const& worldComm = Environment::worldComm() );
+    ModelOutput( ModelOutput const& ) = default;
+    ModelOutput( ModelOutput&& ) = default;
+    ModelOutput& operator=( ModelOutput const& ) = default;
+    ModelOutput& operator=( ModelOutput && ) = default;
+    ModelOutput( std::string name, pt::ptree const& p,
+                 WorldComm const& worldComm = Environment::worldComm(),
+                 std::string const& directoryLibExpr = "" );
+
+    std::string name() const { return M_name; }
+    std::string type() const { return M_type; }
+    std::set<std::string> range() const { return M_range; }
+    int dim() const { return M_dim; }
+
+  private:
+    WorldComm const * M_worldComm;
+    pt::ptree M_p;
+    std::string M_directoryLibExpr;
+
+    std::string M_name;
+    std::string M_type;
+    std::set<std::string> M_range;
+    int M_dim;
+};
+
+std::ostream& operator<<( std::ostream& os, ModelOutput const& o );
+
+class FEELPP_EXPORT ModelOutputs: public std::map<std::string,ModelOutput>
+{
+  public:
+    using value_type = std::map<std::string,ModelOutput>::value_type;
+    ModelOutputs( WorldComm const& worldComm = Environment::worldComm() );
+    ModelOutputs( pt::ptree const& p, WorldComm const& worldComm = Environment::worldComm() );
+    virtual ~ModelOutputs() = default;
+    void setPTree( pt::ptree const& _p ) { M_p = _p; setup(); }
+    ModelOutput loadOutput( std::string const&, std::string );
+    ModelOutput getOutput( pt::ptree const&, std::string );
+
+    ModelOutput const& output( std::string const& o ) const
+    {
+        auto it = this->find( o );
+        if( it == this->end() )
+            throw std::invalid_argument( std::string("ModelOutput: Invalid output name ") + o );
+        return it->second;
+    }
+
+    void setDirectoryLibExpr( std::string const& directoryLibExpr ) { M_directoryLibExpr = directoryLibExpr; }
+
+  private:
+    void setup();
+
+    WorldComm const* M_worldComm;
+    pt::ptree M_p;
+    std::string M_directoryLibExpr;
+
+};
+
+}
+#endif

--- a/feel/feelmodels/modeloutputs.hpp
+++ b/feel/feelmodels/modeloutputs.hpp
@@ -31,6 +31,17 @@ namespace Feel {
 
 namespace pt =  boost::property_tree;
 
+/** \class ModelOutput
+ * \brief class containing an output
+ *
+ * an output is a name, a type, a range and a dimension
+ * "myoutput":
+ * {
+ *   "type": "mytype",
+ *   "range": ["marker1","marker2"],
+ *   "topodim": 2
+ * }
+ */
 class FEELPP_EXPORT ModelOutput
 {
   public:
@@ -47,6 +58,7 @@ class FEELPP_EXPORT ModelOutput
     std::string type() const { return M_type; }
     std::set<std::string> range() const { return M_range; }
     int dim() const { return M_dim; }
+    std::string getString( std::string const& key ) const;
 
   private:
     WorldComm const * M_worldComm;
@@ -61,6 +73,17 @@ class FEELPP_EXPORT ModelOutput
 
 std::ostream& operator<<( std::ostream& os, ModelOutput const& o );
 
+/** \class ModelOutputs
+ * \brief class containing all outputs in the model
+ *
+ * key: name of the output
+ * value: ModelOutput
+ * "Outputs":
+ * {
+ *   "myoutput1":{...},
+ *   "myoutput2":{...}
+ * }
+ */
 class FEELPP_EXPORT ModelOutputs: public std::map<std::string,ModelOutput>
 {
   public:
@@ -69,8 +92,8 @@ class FEELPP_EXPORT ModelOutputs: public std::map<std::string,ModelOutput>
     ModelOutputs( pt::ptree const& p, WorldComm const& worldComm = Environment::worldComm() );
     virtual ~ModelOutputs() = default;
     void setPTree( pt::ptree const& _p ) { M_p = _p; setup(); }
-    ModelOutput loadOutput( std::string const&, std::string );
-    ModelOutput getOutput( pt::ptree const&, std::string );
+    ModelOutput loadOutput( std::string const&, std::string const& );
+    ModelOutput getOutput( pt::ptree const&, std::string const& );
 
     ModelOutput const& output( std::string const& o ) const
     {

--- a/feel/feelmodels/modelproperties.cpp
+++ b/feel/feelmodels/modelproperties.cpp
@@ -40,7 +40,8 @@ ModelProperties::ModelProperties( std::string const& filename, std::string const
     M_mat( world ),
     M_bc( world, false ),
     M_ic( world, false ),
-    M_postproc( world )
+    M_postproc( world ),
+    M_outputs( world )
 {
     if ( !fs::exists( filename ) ) 
     {
@@ -153,6 +154,18 @@ ModelProperties::ModelProperties( std::string const& filename, std::string const
     else
     {
         LOG(WARNING) << "Model does not have any postprocess\n";
+    }
+    auto out = M_p.get_child_optional("Outputs");
+    if ( out )
+    {
+        LOG(INFO) << "Model with outputs\n";
+        if ( !directoryLibExpr.empty() )
+            M_outputs.setDirectoryLibExpr( directoryLibExpr );
+        M_outputs.setPTree( *out );
+    }
+    else
+    {
+        LOG(WARNING) << "Model does not have any outputs\n";
     }
 }
 

--- a/feel/feelmodels/modelproperties.cpp
+++ b/feel/feelmodels/modelproperties.cpp
@@ -115,10 +115,6 @@ ModelProperties::ModelProperties( std::string const& filename, std::string const
             M_bc.setDirectoryLibExpr( directoryLibExpr );
         M_bc.setPTree( *bc );
     }
-    else
-    {
-        LOG(WARNING) << "Model does not have any boundary conditions\n";
-    }
     auto ic = M_p.get_child_optional("InitialConditions");
     if ( ic )
     {
@@ -126,10 +122,6 @@ ModelProperties::ModelProperties( std::string const& filename, std::string const
         if ( !directoryLibExpr.empty() )
             M_ic.setDirectoryLibExpr( directoryLibExpr );
         M_ic.setPTree( *ic );
-    }
-    else
-    {
-        LOG(WARNING) << "Model does not have any initial conditions\n";
     }
     auto mat = M_p.get_child_optional("Materials");
     if ( mat )
@@ -139,10 +131,6 @@ ModelProperties::ModelProperties( std::string const& filename, std::string const
             M_mat.setDirectoryLibExpr( directoryLibExpr );
         M_mat.setPTree( *mat );
     }
-    else
-    {
-        LOG(WARNING) << "Model does not have any materials\n";
-    }
     auto pp = M_p.get_child_optional("PostProcess");
     if ( pp )
     {
@@ -151,10 +139,6 @@ ModelProperties::ModelProperties( std::string const& filename, std::string const
             M_postproc.setDirectoryLibExpr( directoryLibExpr );
         M_postproc.setPTree( *pp );
     }
-    else
-    {
-        LOG(WARNING) << "Model does not have any postprocess\n";
-    }
     auto out = M_p.get_child_optional("Outputs");
     if ( out )
     {
@@ -162,10 +146,6 @@ ModelProperties::ModelProperties( std::string const& filename, std::string const
         if ( !directoryLibExpr.empty() )
             M_outputs.setDirectoryLibExpr( directoryLibExpr );
         M_outputs.setPTree( *out );
-    }
-    else
-    {
-        LOG(WARNING) << "Model does not have any outputs\n";
     }
 }
 

--- a/feel/feelmodels/modelproperties.hpp
+++ b/feel/feelmodels/modelproperties.hpp
@@ -31,6 +31,7 @@
 #include <feel/feelmodels/modelmaterials.hpp>
 #include <feel/feelmodels/modelpostprocess.hpp>
 #include <feel/feelmodels/modelfunctions.hpp>
+#include <feel/feelmodels/modeloutputs.hpp>
 #include <feel/feelpde/boundaryconditions.hpp>
 
 
@@ -77,6 +78,9 @@ public:
     ModelFunctions & functions() { return M_functions; }
     ModelFunctions const& functions() const { return M_functions; }
 
+    ModelOutputs & outputs() { return M_outputs; }
+    ModelOutputs const& outputs() const { return M_outputs; }
+
     std::string getEntry(std::string &s);
 
     void saveMD(std::ostream &os);
@@ -104,6 +108,7 @@ private:
     BoundaryConditions M_ic; // Initial conditions
     ModelPostprocess M_postproc;
     ModelFunctions M_functions;
+    ModelOutputs M_outputs;
 };
 
 

--- a/testsuite/feelmodels/CMakeLists.txt
+++ b/testsuite/feelmodels/CMakeLists.txt
@@ -24,4 +24,4 @@
 
 set_directory_properties(PROPERTIES LABEL testmodels )
 
-feelpp_add_test( modelproperties CFG test.feelpp CLI "--nochdir")
+feelpp_add_test( modelproperties CFG modelproperties.cfg test.feelpp)

--- a/testsuite/feelmodels/modelproperties.cfg
+++ b/testsuite/feelmodels/modelproperties.cfg
@@ -1,0 +1,1 @@
+json_filename=$cfgdir/test.feelpp

--- a/testsuite/feelmodels/test.feelpp
+++ b/testsuite/feelmodels/test.feelpp
@@ -85,6 +85,21 @@
             "x1":"{0.15,0.2}",
             "x2":"{0.25,0.2}"
         }
+    },
+    "Outputs":
+    {
+        "myoutput":
+        {
+            "type":"average",
+            "range":["marker1","marker2"],
+            "topodim":3
+        },
+        "flux":
+        {
+            "type":"flux",
+            "range":"face1",
+            "topodim":2
+        }
     }
 }
 

--- a/testsuite/feelmodels/test_modelproperties.cpp
+++ b/testsuite/feelmodels/test_modelproperties.cpp
@@ -31,19 +31,42 @@
 #include <feel/feelfilters/loadmesh.hpp>
 #include <feel/feelvf/vf.hpp>
 
-FEELPP_ENVIRONMENT_NO_OPTIONS
+using namespace Feel;
+
+inline
+po::options_description
+makeOptions()
+{
+    po::options_description modelopt( "test model properties options" );
+    modelopt.add_options()
+        ("json_filename" , Feel::po::value<std::string>()->default_value( "$cfgdir/test.feelpp" ),
+         "json file" )
+        ;
+    return  modelopt.add( Feel::feel_options() ) ;
+}
+
+inline
+AboutData
+makeAbout()
+{
+    AboutData about( "test_modelproperties",
+                     "test_modelproperties" );
+    return about;
+
+}
+
+FEELPP_ENVIRONMENT_WITH_OPTIONS( makeAbout(), makeOptions() )
 
 BOOST_AUTO_TEST_SUITE( modelproperties )
 
 BOOST_AUTO_TEST_CASE( test_materials )
 {
-    using namespace Feel;
     auto mesh = loadMesh(new Mesh<Simplex<3> >);
     auto Xh = Pch<1>(mesh);
     auto g = Xh->element();
     auto d = Xh->element();
 
-    ModelProperties model_props( Environment::expand("$testsuite_srcdir/feelmodels/test.feelpp" ) );
+    ModelProperties model_props( Environment::expand(soption("json_filename")) );
     auto mats = model_props.materials();
     for ( auto matPair : mats )
     {
@@ -98,8 +121,7 @@ BOOST_AUTO_TEST_CASE( test_materials )
 
 BOOST_AUTO_TEST_CASE( test_parameters )
 {
-    using namespace Feel;
-    ModelProperties model_props( Environment::expand("$testsuite_srcdir/feelmodels/test.feelpp" ) );
+    ModelProperties model_props( Environment::expand(soption("json_filename")) );
     auto param = model_props.parameters();
     for ( auto const& pp : param )
     {
@@ -127,8 +149,7 @@ BOOST_AUTO_TEST_CASE( test_parameters )
 
 BOOST_AUTO_TEST_CASE( test_outputs )
 {
-    using namespace Feel;
-    ModelProperties model_props( Environment::expand("$testsuite_srcdir/feelmodels/test.feelpp" ) );
+    ModelProperties model_props( Environment::expand(soption("json_filename")) );
     auto outputs = model_props.outputs();
     for( auto const& out : outputs )
     {


### PR DESCRIPTION
- add ModelOutputs to ModelProperties
- ModelOutputs is just a map of <string,ModelOutput>
- ModelOutput is just a class containing a name, a type, a range and a dimension
- change testsuite of modelproperties to check basic data

First draft for #1051 