### PR TITLE
Fix Stokes/Stationary conflict

### DIFF
--- a/toolboxes/feel/feelmodels/fluid/fluidmechanics.hpp
+++ b/toolboxes/feel/feelmodels/fluid/fluidmechanics.hpp
@@ -516,6 +516,8 @@ public :
     std::string const& solverName() const;
     void setSolverName( std::string const& type );
 
+    bool isStationaryModel() const;
+
     void setDynamicViscosityLaw( std::string const& type);
     std::string const& dynamicViscosityLaw() const;
 

--- a/toolboxes/feel/feelmodels/fluid/fluidmechanicscreate.cpp
+++ b/toolboxes/feel/feelmodels/fluid/fluidmechanicscreate.cpp
@@ -1911,7 +1911,7 @@ FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::initInHousePreconditioner()
         auto massbf = form2( _trial=this->functionSpaceVelocity(), _test=this->functionSpaceVelocity());
         auto const& u = this->fieldVelocity();
         double coeff = this->densityViscosityModel()->cstRho()*this->timeStepBDF()->polyDerivCoefficient(0);
-        if ( this->isStationary() ) coeff=1.;
+        if ( this->isStationaryModel() ) coeff=1.;
         massbf += integrate( _range=elements( this->mesh() ), _expr=coeff*inner( idt(u),id(u) ) );
         massbf.matrixPtr()->close();
         this->algebraicFactory()->preconditionerTool()->attachAuxiliarySparseMatrix( "mass-matrix", massbf.matrixPtr() );
@@ -2033,8 +2033,6 @@ FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::initInHousePreconditioner()
 
         if ( buildPrecBlockns )
         {
-            // auto myalpha = (this->isStationary())? 0 : this->densityViscosityModel()->cstRho()*this->timeStepBDF()->polyDerivCoefficient(0);
-            //auto myalpha = (!this->isStationary())*idv(this->densityViscosityModel()->fieldRho())*this->timeStepBDF()->polyDerivCoefficient(0);
             typedef space_fluid_type space_type;
             typedef space_densityviscosity_type properties_space_type;
             boost::shared_ptr< PreconditionerBlockNS<space_type, properties_space_type> > a_blockns =

--- a/toolboxes/feel/feelmodels/fluid/fluidmechanicsothers.cpp
+++ b/toolboxes/feel/feelmodels/fluid/fluidmechanicsothers.cpp
@@ -258,6 +258,11 @@ FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::setModelName( std::string const& type )
         M_modelName="Stokes";
         M_solverName="LinearSystem";
     }
+    else if ( type == "StokesTransient" )
+    {
+        M_modelName="StokesTransient";
+        M_solverName="LinearSystem";
+    }
     else if ( type == "Oseen" ) // not realy a model but a solver for navier stokes
     {
         M_modelName="Navier-Stokes";
@@ -309,6 +314,18 @@ std::string const&
 FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::solverName() const
 {
     return M_solverName;
+}
+
+//---------------------------------------------------------------------------------------------------------//
+
+FLUIDMECHANICS_CLASS_TEMPLATE_DECLARATIONS
+bool
+FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::isStationaryModel() const
+{
+    if( this->modelName() == "Stokes" )
+        return true;
+    else
+        return this->isStationary();
 }
 
 //---------------------------------------------------------------------------------------------------------//
@@ -1072,12 +1089,12 @@ FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::updateInHousePreconditionerPCD( sparse_matri
         boost::shared_ptr< PreconditionerBlockNS<space_type, properties_space_type> > myPrecBlockNs =
             boost::dynamic_pointer_cast< PreconditionerBlockNS<space_type, properties_space_type> >( this->algebraicFactory()->preconditionerTool()->inHousePreconditioners( "blockns" ) );
 
-        if ( !this->isStationary() )
+        if ( !this->isStationaryModel() )
             myPrecBlockNs->setAlpha( idv(this->densityViscosityModel()->fieldRho())*this->timeStepBDF()->polyDerivCoefficient(0) );
         myPrecBlockNs->setMu( idv(this->densityViscosityModel()->fieldMu()) );
         myPrecBlockNs->setRho( idv(this->densityViscosityModel()->fieldRho()) );
 
-        if ( this->modelName() == "Stokes" )
+        if ( this->modelName() == "Stokes" || this->modelName() == "StokesTransient" )
         {
             myPrecBlockNs->update( mat );
         }
@@ -1125,10 +1142,10 @@ FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::updateInHousePreconditionerPCD( sparse_matri
             boost::dynamic_pointer_cast< OperatorPCD<space_fluid_type> >( this->algebraicFactory()->preconditionerTool()->operatorPCD( "pcd" ) );
         auto const& rho = this->densityViscosityModel()->fieldRho();
         auto const& mu = this->densityViscosityModel()->fieldMu();
-        bool hasAlpha = !this->isStationary();
-        double coeffAlpha = (this->isStationary())? 0. : this->timeStepBDF()->polyDerivCoefficient(0);
+        bool hasAlpha = !this->isStationaryModel();
+        double coeffAlpha = (this->isStationaryModel())? 0. : this->timeStepBDF()->polyDerivCoefficient(0);
         auto alpha = idv(rho)*coeffAlpha;
-        if ( this->modelName() == "Stokes" )
+        if ( this->modelName() == "Stokes" || this->modelName() == "StokesTransient" )
         {
             if (this->isMoveDomain() )
             {

--- a/toolboxes/feel/feelmodels/fluid/fluidmechanicsupdatejacobian.cpp
+++ b/toolboxes/feel/feelmodels/fluid/fluidmechanicsupdatejacobian.cpp
@@ -193,7 +193,7 @@ FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::updateJacobian( DataUpdateJacobian & data ) 
     bool Build_TransientTerm = !BuildCstPart;
     if ( this->timeStepBase()->strategy()==TS_STRATEGY_DT_CONSTANT ) Build_TransientTerm=BuildCstPart;
 
-    if (!this->isStationary() && Build_TransientTerm/*BuildCstPart*/)
+    if (!this->isStationaryModel() && Build_TransientTerm/*BuildCstPart*/)
     {
         bilinearForm_PatternDefault +=
             integrate( _range=M_rangeMeshElements,

--- a/toolboxes/feel/feelmodels/fluid/fluidmechanicsupdatelinear.cpp
+++ b/toolboxes/feel/feelmodels/fluid/fluidmechanicsupdatelinear.cpp
@@ -252,7 +252,8 @@ FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::updateLinearPDE( DataUpdateLinear & data ) c
         double timeElapsedConvection = this->timerTool("Solve").stop();
         this->log("FluidMechanics","updateLinearPDE","assembly convection in "+(boost::format("%1% s") %timeElapsedConvection).str() );
     }
-    else if ( this->modelName() == "Stokes" && build_ConvectiveTerm && this->isMoveDomain() )
+    else if ( (this->modelName() == "Stokes" || this->modelName() == "StokesTransient") 
+            && build_ConvectiveTerm && this->isMoveDomain() )
     {
 #if defined( FEELPP_MODELS_HAS_MESHALE )
         bilinearForm_PatternDefault +=
@@ -266,7 +267,7 @@ FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::updateLinearPDE( DataUpdateLinear & data ) c
 
     //--------------------------------------------------------------------------------------------------//
     //transients terms
-    if (!this->isStationary())
+    if (!this->isStationaryModel())
     {
         if (build_Form2TransientTerm)
         {

--- a/toolboxes/feel/feelmodels/fluid/fluidmechanicsupdateresidual.cpp
+++ b/toolboxes/feel/feelmodels/fluid/fluidmechanicsupdateresidual.cpp
@@ -236,7 +236,7 @@ FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::updateResidual( DataUpdateResidual & data ) 
     //------------------------------------------------------------------------------------//
 
     //transients terms
-    if (!this->isStationary())
+    if (!this->isStationaryModel())
     {
         bool Build_TransientTerm = !BuildCstPart;
         if ( this->timeStepBase()->strategy()==TS_STRATEGY_DT_CONSTANT ) Build_TransientTerm=!BuildCstPart && !UseJacobianLinearTerms;

--- a/toolboxes/feel/feelmodels/fluid/fluidmechanicsupdatestabilisationgls.cpp
+++ b/toolboxes/feel/feelmodels/fluid/fluidmechanicsupdatestabilisationgls.cpp
@@ -195,7 +195,7 @@ updateLinearPDEStabilizationGLS( FluidMechanicsType const& fluidmec, ModelAlgebr
         auto tau = Feel::vf::FeelModels::stabilizationGLSParameterExpr( *fluidmec.stabilizationGLSParameterConvectionDiffusion(), uconv, myViscosity );
 #endif
         auto stab_test = stabGLStestLinearExpr_u( idv(rho),myViscosity,idv(betaU),u, mpl::int_<StabGLSType>() );
-        if (!fluidmec.isStationary())
+        if (!fluidmec.isStationaryModel())
         {
             auto stab_residual_bilinear_u = residualTransientLinearExpr_u( idv(rho),myViscosity,idv(betaU),u,fluidmec, mpl::int_<StabResidualType>() );
             bilinearForm_PatternCoupled +=
@@ -249,7 +249,7 @@ updateLinearPDEStabilizationGLS( FluidMechanicsType const& fluidmec, ModelAlgebr
 #endif
 
         auto stab_test = -idv(rho)*trans(grad(p));
-        if ( !fluidmec.isStationary() )
+        if ( !fluidmec.isStationaryModel() )
         {
             auto stab_residual_bilinear_u = residualTransientLinearExpr_u( idv(rho),myViscosity,idv(betaU),u,fluidmec, mpl::int_<StabResidualType>() );
             bilinearForm_PatternCoupled +=
@@ -331,7 +331,7 @@ updateLinearPDEStabilizationGLSStokes( FluidMechanicsType const& fluidmec, Model
 #endif
 
     auto stab_test = -rho*trans(grad(p));
-    if ( !fluidmec.isStationary() )
+    if ( !fluidmec.isStationaryModel() )
     {
         if ( FluidMechanicsType::nOrderVelocity>1 )
         {
@@ -422,7 +422,7 @@ updateResidualStabilizationGLS( FluidMechanicsType const& fluidmec, ModelAlgebra
 #endif
         //auto stab_test = grad(u)*uconv - myViscosity*laplacian(u);
         auto stab_test = stabGLStestLinearExpr_u( idv(rho),myViscosity,idv(u),u, mpl::int_<StabGLSType>() );
-        if (!fluidmec.isStationary())
+        if (!fluidmec.isStationaryModel())
         {
             auto const& rhsTimeDerivativeVP = fluidmec.timeStepBDF()->polyDeriv();
             auto rhsTimeDerivative = rhsTimeDerivativeVP.template element<0>();
@@ -467,7 +467,7 @@ updateResidualStabilizationGLS( FluidMechanicsType const& fluidmec, ModelAlgebra
 #endif
 
         auto stab_test = -idv(rho)*trans(grad(p));
-        if ( !fluidmec.isStationary() )
+        if ( !fluidmec.isStationaryModel() )
         {
             auto const& rhsTimeDerivativeVP = fluidmec.timeStepBDF()->polyDeriv();
             auto rhsTimeDerivative = rhsTimeDerivativeVP.template element<0>();
@@ -542,7 +542,7 @@ updateJacobianStabilizationGLS( FluidMechanicsType const& fluidmec, ModelAlgebra
         auto tau = Feel::vf::FeelModels::stabilizationGLSParameterExpr( *fluidmec.stabilizationGLSParameterConvectionDiffusion(), uconv, myViscosity );
 #endif
         auto stab_test = stabGLStestLinearExpr_u( idv(rho),myViscosity,idv(u),u, mpl::int_<StabGLSType>() );
-        if (!fluidmec.isStationary())
+        if (!fluidmec.isStationaryModel())
         {
             auto stab_residual_bilinear_u = residualTransientJacobianExpr_u( idv(rho),myViscosity,u,fluidmec, mpl::int_<StabResidualType>() );
             bilinearForm_PatternCoupled +=
@@ -578,7 +578,7 @@ updateJacobianStabilizationGLS( FluidMechanicsType const& fluidmec, ModelAlgebra
         auto tau = Feel::vf::FeelModels::stabilizationGLSParameterExpr( *fluidmec.stabilizationGLSParameterPressure(), uconv, myViscosity );
 #endif
         auto stab_test = -idv(rho)*trans(grad(p));
-        if ( !fluidmec.isStationary() )
+        if ( !fluidmec.isStationaryModel() )
         {
             auto stab_residual_bilinear_u = residualTransientJacobianExpr_u( idv(rho),myViscosity,u,fluidmec, mpl::int_<StabResidualType>() );
             bilinearForm_PatternCoupled +=
@@ -624,7 +624,7 @@ FLUIDMECHANICS_CLASS_TEMPLATE_TYPE::updateLinearPDEStabilisationGLS( DataUpdateL
                 FluidMechanicsDetail::updateLinearPDEStabilizationGLS<1>( *this, data );
             }
         }
-        else if ( this->modelName() == "Stokes")
+        else if ( this->modelName() == "Stokes" || this->modelName() == "StokesTransient" )
         {
             CHECK( this->stabilizationGLSType() == "pspg" ) << "only pspg stab for Stokes";
             FluidMechanicsDetail::updateLinearPDEStabilizationGLSStokes( *this, data );


### PR DESCRIPTION
This fixes Stokes model (no transient term in the usual Stokes equation) while allowing time evolution (i.e. non-stationary problem). This also adds the StokesTransient model (solving Stokes equation with a $\rho \frac{\partial u}{\partial t}$ term) which replaces the old Stokes model. 

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [ ] Have you successfully run the Feel++ testsuite with your changes locally?

-----
