### PR TITLE
fix #1229

### DIFF
--- a/feelpp/feel/feelalg/enums.cpp
+++ b/feelpp/feel/feelalg/enums.cpp
@@ -56,6 +56,9 @@ std::map<std::string, size_type> EigenMap = {
     {"smallest_real", SMALLEST_REAL },
     {"largest_imaginary", LARGEST_IMAGINARY },
     {"smallest_imaginary", SMALLEST_IMAGINARY },
+    {"target_magnitude", TARGET_MAGNITUDE },
+    {"target_real", TARGET_REAL },
+    {"target_imaginary", TARGET_IMAGINARY },
     // spectral transform type
     {"shift", SHIFT },
     {"shift_invert", SINVERT },

--- a/feelpp/feel/feelalg/enums.cpp
+++ b/feelpp/feel/feelalg/enums.cpp
@@ -56,9 +56,11 @@ std::map<std::string, size_type> EigenMap = {
     {"smallest_real", SMALLEST_REAL },
     {"largest_imaginary", LARGEST_IMAGINARY },
     {"smallest_imaginary", SMALLEST_IMAGINARY },
+#if (SLEPC_VERSION_MAJOR == 3) && (SLEPC_VERSION_MINOR >= 9)
     {"target_magnitude", TARGET_MAGNITUDE },
     {"target_real", TARGET_REAL },
     {"target_imaginary", TARGET_IMAGINARY },
+#endif
     // spectral transform type
     {"shift", SHIFT },
     {"shift_invert", SINVERT },

--- a/feelpp/feel/feelalg/enums.hpp
+++ b/feelpp/feel/feelalg/enums.hpp
@@ -243,6 +243,9 @@ enum PositionOfSpectrum {LARGEST_MAGNITUDE=0,
                          SMALLEST_REAL,
                          LARGEST_IMAGINARY,
                          SMALLEST_IMAGINARY,
+                         TARGET_MAGNITUDE,
+                         TARGET_REAL,
+                         TARGET_IMAGINARY,
 
                          INVALID_Postion_of_Spectrum
                         };

--- a/feelpp/feel/feelalg/enums.hpp
+++ b/feelpp/feel/feelalg/enums.hpp
@@ -243,10 +243,11 @@ enum PositionOfSpectrum {LARGEST_MAGNITUDE=0,
                          SMALLEST_REAL,
                          LARGEST_IMAGINARY,
                          SMALLEST_IMAGINARY,
+#if (SLEPC_VERSION_MAJOR == 3) && (SLEPC_VERSION_MINOR >= 9)
                          TARGET_MAGNITUDE,
                          TARGET_REAL,
                          TARGET_IMAGINARY,
-
+#endif
                          INVALID_Postion_of_Spectrum
                         };
 

--- a/feelpp/feel/feelalg/solvereigenslepc.cpp
+++ b/feelpp/feel/feelalg/solvereigenslepc.cpp
@@ -704,6 +704,7 @@ SolverEigenSlepc<T>:: setSlepcPositionOfSpectrum()
         CHKERRABORT( PETSC_COMM_WORLD,ierr );
         return;
 
+#if (SLEPC_VERSION_MAJOR == 3) && (SLEPC_VERSION_MINOR >= 9)
     case TARGET_MAGNITUDE:
         ierr = EPSSetWhichEigenpairs ( M_eps, EPS_TARGET_MAGNITUDE );
         CHKERRABORT( PETSC_COMM_WORLD,ierr );
@@ -718,7 +719,7 @@ SolverEigenSlepc<T>:: setSlepcPositionOfSpectrum()
         ierr = EPSSetWhichEigenpairs ( M_eps, EPS_TARGET_IMAGINARY );
         CHKERRABORT( PETSC_COMM_WORLD,ierr );
         return;
-
+#endif
 
     default:
         std::cerr << "ERROR:  Unsupported SLEPc position of spectrum: "

--- a/feelpp/feel/feelalg/solvereigenslepc.cpp
+++ b/feelpp/feel/feelalg/solvereigenslepc.cpp
@@ -704,6 +704,21 @@ SolverEigenSlepc<T>:: setSlepcPositionOfSpectrum()
         CHKERRABORT( PETSC_COMM_WORLD,ierr );
         return;
 
+    case TARGET_MAGNITUDE:
+        ierr = EPSSetWhichEigenpairs ( M_eps, EPS_TARGET_MAGNITUDE );
+        CHKERRABORT( PETSC_COMM_WORLD,ierr );
+        return;
+
+    case TARGET_REAL:
+        ierr = EPSSetWhichEigenpairs ( M_eps, EPS_TARGET_REAL );
+        CHKERRABORT( PETSC_COMM_WORLD,ierr );
+        return;
+
+    case TARGET_IMAGINARY:
+        ierr = EPSSetWhichEigenpairs ( M_eps, EPS_TARGET_IMAGINARY );
+        CHKERRABORT( PETSC_COMM_WORLD,ierr );
+        return;
+
 
     default:
         std::cerr << "ERROR:  Unsupported SLEPc position of spectrum: "

--- a/feelpp/feel/options.cpp
+++ b/feelpp/feel/options.cpp
@@ -528,7 +528,7 @@ solvereigen_options( std::string const& prefix )
     // solver options
         ( ( _prefix+"solvereigen.solver" ).c_str(), Feel::po::value<std::string>()->default_value( "krylovschur" ), "type of eigenvalue solver. Choice: power,lapack,subspace,arnoldi,krylovschur,arpack" )
         ( ( _prefix+"solvereigen.problem" ).c_str(), Feel::po::value<std::string>()->default_value( "ghep" ), "type of eigenvalue problem. Choice: nhep, hep, gnhep, ghep, pgnhep" )
-        ( ( _prefix+"solvereigen.spectrum" ).c_str(), Feel::po::value<std::string>()->default_value( "largest_magnitude" ), "eigenvalue solver position in spectrum. Choice: largest_magnitude, smallest_magnitude, largest_real, smallest_real, largest_imaginary, smallest_imaginary" )
+        ( ( _prefix+"solvereigen.spectrum" ).c_str(), Feel::po::value<std::string>()->default_value( "largest_magnitude" ), "eigenvalue solver position in spectrum. Choice: largest_magnitude, smallest_magnitude, largest_real, smallest_real, largest_imaginary, smallest_imaginary, target_magnitude, target_real, target_imaginary" )
         ( ( _prefix+"solvereigen.transform" ).c_str(), Feel::po::value<std::string>()->default_value( "shift" ), "spectral transformation. Choice: shift, shift_invert, fold, cayley" )
         ( ( _prefix+"solvereigen.nev" ).c_str(), Feel::po::value<int>()->default_value( 1 ), "number of requested eigenpairs" )
         ( ( _prefix+"solvereigen.ncv" ).c_str(), Feel::po::value<int>()->default_value( 2 ), "dimension of the subspace" )

--- a/testsuite/feelalg/test_eigenmode.cfg
+++ b/testsuite/feelalg/test_eigenmode.cfg
@@ -3,3 +3,4 @@ hsize=0.2
 
 [solvereigen]
 eps-target=20
+spectrum=target_real

--- a/testsuite/feelalg/test_eigenmode.cpp
+++ b/testsuite/feelalg/test_eigenmode.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE( test_0 )
                         _solver="krylovschur",
                         _problem="ghep",
                         _transform="shift_invert",
-                        _spectrum="smallest_magnitude",
+                        _spectrum=soption("solvereigen.spectrum"),
                         _nev=15,
                         _ncv=30,
                         _verbose=1

--- a/testsuite/feelalg/test_eigenmode.cpp
+++ b/testsuite/feelalg/test_eigenmode.cpp
@@ -36,7 +36,10 @@ BOOST_AUTO_TEST_CASE( test_0 )
                         _solver="krylovschur",
                         _problem="ghep",
                         _transform="shift_invert",
-                        _spectrum=soption("solvereigen.spectrum"),
+#if (SLEPC_VERSION_MAJOR == 3) && (SLEPC_VERSION_MINOR >= 9)
+                        _spectrum="target_real",
+#else
+                        _spectrum="smallest_magnitude",
                         _nev=15,
                         _ncv=30,
                         _verbose=1


### PR DESCRIPTION
- add options for the position of spectrum: target_magnitude target_real and
target_imaginary
- take them into account in solvereigenslepc
- use it in test eigenmode

- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [ ] Have you successfully run the Feel++ testsuite with your changes locally?
- [ ] Have you written Doxygen comments in your contribution ?

-----
