### PR TITLE
Feature/partition ofile odir

### DIFF
--- a/feelpp/tools/mesh/mesh_partitioner.hpp
+++ b/feelpp/tools/mesh/mesh_partitioner.hpp
@@ -110,21 +110,24 @@ void partition( std::vector<int> const& nParts)
 
         for ( int nPartition : nParts )
         {
-
-            std::string outputFilenameWithoutExt = (boost::format("%1%_p%2%")%inputFilenameWithoutExt %nPartition ).str();
+            std::string outputFilenameWithoutExt = "";
+            if( Environment::vm().count("ofile") )
+            {
+                std::string ofile = fs::path( soption("ofile")).stem().string();
+                if( nParts.size() == 1 )
+                    outputFilenameWithoutExt = ofile;
+                else
+                    outputFilenameWithoutExt = (boost::format("%1%_p%2%")%ofile %nPartition ).str();
+            }
+            else
+                outputFilenameWithoutExt = (boost::format("%1%_p%2%")%inputFilenameWithoutExt %nPartition ).str();
             std::string outputFilenameWithExt = outputFilenameWithoutExt + ".json";
-            std::string outputPathMesh = ( fs::current_path() / fs::path(outputFilenameWithExt) ).string();
-            if ( Environment::vm().count("ofile") )
-            {
-                outputPathMesh = fs::system_complete( soption("ofile") ).string();
-                if ( fs::path(outputPathMesh).extension() != ".json" )
-                    outputPathMesh = outputPathMesh + ".json";
-            }
-            else if ( Environment::vm().count("odir") )
-            {
-                fs::path odir = fs::system_complete( soption("odir") ).string();
-                outputPathMesh = (odir / fs::path(outputFilenameWithExt) ).string();
-            }
+            fs::path outputDirPath;
+            if ( Environment::vm().count("odir") )
+                outputDirPath = fs::system_complete( soption("odir") );
+            else
+                outputDirPath = fs::current_path();
+            std::string outputPathMesh = ( outputDirPath / fs::path(outputFilenameWithExt) ).string();
 
             fs::path outputDir = fs::path(outputPathMesh).parent_path();
             if ( !fs::exists( outputDir ) )

--- a/feelpp/tools/mesh/partitioner.adoc
+++ b/feelpp/tools/mesh/partitioner.adoc
@@ -12,17 +12,14 @@ Christophe Prud'homme <https://github.com/prudhomm[@prudhomm]>; Vincent Chabanne
 
 == SYNOPSIS
 
+{manmanual} --part num [num2...] --ifile file [--dim d] [--shape s] [--order num] [--by-markers] [--by-markers-desc markers] [--ofile file] [--odir dir]
+
+== DESCRIPTION
+
 {manmanual} is a simple application which can generate a partitioned mesh and
 save it in a Feel++ specific `json+hdf5` file format.
 
 The generated mesh can then be loaded very efficiently in parallel.
-
-
-== DESCRIPTION
-
-
-
-== OPTIONS
 
 === Options
 
@@ -79,10 +76,10 @@ Often we are interested in a set of partitioned meshes in order to do a speed-up
 
 [source,shell]
 ----
-feelpp_mesh_partitioner --part 2 4 8 16 32  --ifile src/feelpp/data/gmsh/primitives/torus.geo --odir torus
+feelpp_mesh_partitioner --part 2 4 8 16 32  --ifile src/feelpp/data/gmsh/primitives/torus.geo --odir torus-mesh
 ----
 
-You should have in the  directory `torus` (thanks to the `odir` option) 5 partitioned meshes
+You should have in the  directory `torus-mesh` (thanks to the `odir` option) 5 partitioned meshes
 
 [source,shell]
 ----
@@ -92,6 +89,8 @@ torus_p16.json  torus_p2.json  torus_p32.json  torus_p4.json  torus_p8.json
 ----
 
 NOTE: The mesh filenames contain the partition information.
+
+NOTE: If you want a different prefix than `torus`, like `torus-coarse`, you can use the `--ifile torus-coarse` option and you will have a set of files named `torus-coarse_p*.*` in the `torus-mesh` directory.
 
 === Generating a mesh partitioning by markers
 1) partitioning of each marker present in the mesh :


### PR DESCRIPTION
update mesh_partitioner:
- `ofile` is the name of the output file if the number of partitions is 1
- `ofile` is the prefix of the output file if the number of partitions is greater than 1
- `odir` and `ofile` can now be used at the same time