### PR TITLE
Support boost 1.68 with ProductSpaces

### DIFF
--- a/feelpp/feel/feelalg/graphcsr.hpp
+++ b/feelpp/feel/feelalg/graphcsr.hpp
@@ -570,10 +570,11 @@ csrGraphBlocks( PS&& ps,
     BlocksBaseGraphCSR g( s, s );
 
     int n = 0;
-    auto cp = hana::cartesian_product( hana::make_tuple( ps, ps ) );
-    int nstatic = hana::if_(std::is_base_of<ProductSpaceBase,decay_type<decltype(hana::back(ps))>>{},
+    auto pst = ps.tupleSpaces();
+    auto cp = hana::cartesian_product( hana::make_tuple( pst, pst ) );
+    int nstatic = hana::if_(std::is_base_of<ProductSpaceBase,decay_type<decltype(hana::back(pst))>>{},
                             [s] (auto&& x ) { return s-hana::back(std::forward<decltype(x)>(x))->numberOfSpaces()+1; },
-                            [s] (auto&& x ) { return s; } )( ps );
+                            [s] (auto&& x ) { return s; } )( pst );
     hana::for_each( cp, [&]( auto const& e )
                     {
                         int r = n/nstatic;

--- a/feelpp/feel/feelalg/vectorblock.hpp
+++ b/feelpp/feel/feelalg/vectorblock.hpp
@@ -77,7 +77,7 @@ public :
         M_backend( b )
         {
             int n = 0;
-            hana::for_each( ps, [&]( auto const& e )
+            hana::for_each( ps.tupleSpaces(), [&]( auto const& e )
                             {
 
                                 hana::if_(std::is_base_of<ProductSpaceBase,decay_type<decltype(e)>>{},
@@ -489,7 +489,7 @@ blockVector( PS && ps, backend_ptrtype b = backend(),
     BlocksBaseVector<double> g( size, b );
 
     int n = 0;
-    hana::for_each( ps, [&]( auto const& e )
+    hana::for_each( ps.tupleSpaces(), [&]( auto const& e )
                     {
 
                         hana::if_(std::is_base_of<ProductSpaceBase,decay_type<decltype(e)>>{},
@@ -526,12 +526,12 @@ BlocksBaseVector<double>
 blockElement( PS && ps, backend_ptrtype b = backend(),
               std::enable_if_t<std::is_base_of<ProductSpacesBase,std::remove_reference_t<PS>>::value>* = nullptr )
 {
-    const int size = hana::size(ps);
+    const int size = hana::size(ps.tupleSpaces());
     //BlocksBaseVector<typename decay_type<PS>::value_type> g( size, backend() );
     BlocksBaseVector<double> g( size, b );
 
     int n = 0;
-    hana::for_each( ps, [&]( auto const& e )
+    hana::for_each( ps.tupleSpaces(), [&]( auto const& e )
                     {
                         cout << "creating vector element (" << n  << ")\n";
                         g(n,0) = e->elementPtr();

--- a/testsuite/feeldiscr/test_productspaces.cpp
+++ b/testsuite/feeldiscr/test_productspaces.cpp
@@ -82,7 +82,7 @@ makeAbout()
      BOOST_CHECK_EQUAL( sp[0_c], Xh );
      BOOST_CHECK_EQUAL( sp[1_c], Wh );
 
-     auto cp = hana::cartesian_product(hana::make_tuple(sp,sp));
+     auto cp = hana::cartesian_product(hana::make_tuple(sp.tupleSpaces(),sp.tupleSpaces()));
 
      BOOST_CHECK_EQUAL( cp[0_c][0_c], Xh );
      BOOST_CHECK_EQUAL( cp[0_c][1_c], Xh );


### PR DESCRIPTION
ProductSpaces does not inherits of hana::tuple but store the hana tuple as an atribute

- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run the Feel++ testsuite with your changes locally?
- [ ] Have you written Doxygen comments in your contribution ?

-----
should finish #1247