### PR TITLE
CMake: Drop boost.signals detection

### DIFF
--- a/feelpp/cmake/modules/feelpp.dependencies.cmake
+++ b/feelpp/cmake/modules/feelpp.dependencies.cmake
@@ -561,7 +561,7 @@ if(FEELPP_ENABLE_PYTHON_WRAPPING)
 endif()
 
 # Then we try to find rest of the Boost components
-FIND_PACKAGE(Boost ${BOOST_MIN_VERSION} REQUIRED date_time filesystem system program_options unit_test_framework signals ${FEELPP_BOOST_MPI} regex serialization iostreams )
+FIND_PACKAGE(Boost ${BOOST_MIN_VERSION} REQUIRED date_time filesystem system program_options unit_test_framework ${FEELPP_BOOST_MPI} regex serialization iostreams )
 if(Boost_FOUND)
   IF(Boost_MAJOR_VERSION EQUAL "1" AND Boost_MINOR_VERSION GREATER "51")
     #add_definitions(-DBOOST_RESULT_OF_USE_TR1)


### PR DESCRIPTION
signals2 is used and is header-only (signals was dropped in 1.69)

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [ ] Have you successfully run the Feel++ testsuite with your changes locally?
- [ ] Have you written Doxygen comments in your contribution ?

-----
