### PR TITLE
add possibility to load json partitionned mesh automatically

### DIFF
--- a/feelpp/feel/options.cpp
+++ b/feelpp/feel/options.cpp
@@ -197,7 +197,7 @@ gmsh_options( std::string const& prefix )
 
     _options.add_options()
     // gmsh options
-        ( prefixvm( prefix,"gmsh.filename" ).c_str(), Feel::po::value<std::string>()->default_value( "untitled.geo" ), "Gmsh filename" )
+        ( prefixvm( prefix,"gmsh.filename" ).c_str(), Feel::po::value<std::string>()->default_value( "" ), "Gmsh filename" )
         ( prefixvm( prefix,"gmsh.depends" ).c_str(), Feel::po::value<std::string>()->default_value( "" ), "list of files separated by , or ; that are dependencies of a loaded Gmsh geometry" )
         ( prefixvm( prefix,"gmsh.hsize" ).c_str(), Feel::po::value<double>()->default_value( 0.1 ), "default characteristic mesh size" )
         ( prefixvm( prefix,"gmsh.scale" ).c_str(), Feel::po::value<double>()->default_value( 1 ), "scale the mesh after loading" )


### PR DESCRIPTION
change default gmsh.filename to empty string
if filename is not empty but without extension, search for partitionned mesh filename_p<n>.json
if filename is not empty and not found, exit the application
if filename is left empty use hypercube

I think that this behavior would prevent some runtime errors when one wants to run his simulation on a given mesh but make a mistake on its name. Currently, the simulation continues on a hypercube, which I think is not what most of the users want. With this pull request the simulation would stop.
If the user does not change the filename, it will still use the hypercube, allowing quick tests without defining a geo.

Another part is to search for partitioned hdf5 mesh without specifying the number of partitions.
If a user has partitioned his mesh `cube.msh`, giving `gmsh.filename=cube` on 4 procs will look for `cube_p4.json`. It allows to have a unique config file for different number of processor.

- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [ ] Have you successfully run the Feel++ testsuite with your changes locally?
- [ ] Have you written Doxygen comments in your contribution ?

-----
