### PR TITLE
Compilation failing on macOS with clang++

### DIFF
--- a/feelpp/feel/feelalg/functionspetsc.cpp
+++ b/feelpp/feel/feelalg/functionspetsc.cpp
@@ -292,9 +292,13 @@ PetscConvertKSPReasonToString( KSPConvergedReason reason )
 #endif
     case KSP_DIVERGED_INDEFINITE_MAT : return "DIVERGED_INDEFINITE_MAT";
 #if PETSC_VERSION_GREATER_OR_EQUAL_THAN( 3, 6, 0 )
+#if !PETSC_VERSION_GREATER_OR_EQUAL_THAN( 3, 12, 0 )
     case KSP_DIVERGED_PCSETUP_FAILED : return "DIVERGED_PCSETUP_FAILED";
+#else
+    case KSP_DIVERGED_PC_FAILED      : return "DIVERGED_PC_FAILED";
 #endif
-    case KSP_CONVERGED_ITERATING : return "CONVERGED_ITERATING";
+#endif
+    case KSP_CONVERGED_ITERATING     : return "CONVERGED_ITERATING";
 
     default: return "INDEFINE_KSP_REASON";
 
@@ -313,7 +317,9 @@ PetscConvertSNESReasonToString( SNESConvergedReason reason )
     case SNES_CONVERGED_SNORM_RELATIVE : return "CONVERGED_SNORM_RELATIVE";// =  4, /* Newton computed step size small; || delta x || < stol */
 #endif
     case SNES_CONVERGED_ITS            : return "CONVERGED_ITS";           // =  5, /* maximum iterations reached */
+#if !PETSC_VERSION_GREATER_OR_EQUAL_THAN( 3, 12, 0 )
     case SNES_CONVERGED_TR_DELTA       : return "CONVERGED_TR_DELTA";      // =  7,
+#endif
         /* diverged */
     case SNES_DIVERGED_FUNCTION_DOMAIN : return "DIVERGED_FUNCTION_DOMAIN";// = -1, /* the new x location passed the function is not in the domain of F */
     case SNES_DIVERGED_FUNCTION_COUNT  : return "DIVERGED_FUNCTION_COUNT"; // = -2,
@@ -324,9 +330,12 @@ PetscConvertSNESReasonToString( SNESConvergedReason reason )
     case SNES_DIVERGED_LINE_SEARCH     : return "DIVERGED_LINE_SEARCH";    // = -6, /* the line search failed */
 #endif
 #if PETSC_VERSION_GREATER_OR_EQUAL_THAN( 3, 3, 0 )
-        case SNES_DIVERGED_INNER           : return "DIVERGED_INNER";          // = -7, /* inner solve failed */
+    case SNES_DIVERGED_INNER           : return "DIVERGED_INNER";          // = -7, /* inner solve failed */
 #endif
     case SNES_DIVERGED_LOCAL_MIN       : return "DIVERGED_LOCAL_MIN";      // = -8, /* || J^T b || is small, implies converged to local minimum of F() */
+#if PETSC_VERSION_GREATER_OR_EQUAL_THAN( 3, 12, 0 )
+    case SNES_DIVERGED_TR_DELTA        : return "DIVERGED_TR_DELTA";       // =  -11,
+#endif
 
     case SNES_CONVERGED_ITERATING      : return "CONVERGED_ITERATING";     // =  0
 

--- a/feelpp/feel/feelalg/solvereigen.hpp
+++ b/feelpp/feel/feelalg/solvereigen.hpp
@@ -540,7 +540,7 @@ protected:
  *
  * \return eigen modes
  */
-BOOST_PARAMETER_MEMBER_FUNCTION( ( typename SolverEigen<double>::eigenmodes_type ),
+BOOST_PARAMETER_FUNCTION( ( typename SolverEigen<double>::eigenmodes_type ),
                                  eigs,
                                  tag,
                                  ( required
@@ -617,7 +617,7 @@ struct compute_eigs_return_type
     typedef std::vector<std::pair<value_type,typename A_type::element_2_type> > type;
 };
 
-BOOST_PARAMETER_MEMBER_FUNCTION( ( typename compute_eigs_return_type<Args>::type ),
+BOOST_PARAMETER_FUNCTION( ( typename compute_eigs_return_type<Args>::type ),
                                  veigs,
                                  tag,
                                  ( required

--- a/feelpp/feel/feelcore/environment.hpp
+++ b/feelpp/feel/feelcore/environment.hpp
@@ -656,8 +656,8 @@ public:
         ( required
           ( name,( std::string ) ) )
         ( optional
-          ( sub,( std::string ),"" )
-          ( prefix,( std::string ),"" )
+          ( sub,( std::string ),std::string() )
+          ( prefix,( std::string ),std::string() )
           ( vm, ( po::variables_map const& ), Environment::vm() )
         ) )
     {

--- a/feelpp/feel/feeldiscr/functionspace.hpp
+++ b/feelpp/feel/feeldiscr/functionspace.hpp
@@ -4655,7 +4655,7 @@ public:
 
     static pointer_type NewImpl( mesh_ptrtype const& __m,
                                  mesh_support_vector_type const& meshSupport,
-                                 worldscomm_ptr_t & worldscomm = Environment::worldsComm(nSpaces),
+                                 worldscomm_ptr_t const& worldscomm = Environment::worldsComm(nSpaces),
                                  size_type mesh_components = MESH_RENUMBER | MESH_CHECK,
                                  periodicity_type periodicity = periodicity_type(),
                                  std::vector<bool> extendedDofTable = std::vector<bool>(nSpaces,false) )

--- a/feelpp/feel/feelfilters/creategmshmesh.hpp
+++ b/feelpp/feel/feelfilters/creategmshmesh.hpp
@@ -152,7 +152,7 @@ BOOST_PARAMETER_FUNCTION(
                 _meshSeq->components().reset();
                 _meshSeq->components().set( size_type(MESH_UPDATE_ELEMENTS_ADJACENCY|MESH_UPDATE_FACES|MESH_NO_UPDATE_MEASURES|MESH_GEOMAP_NOT_CACHED) );
                 _meshSeq->updateForUse();
-
+#if defined(FEELPP_HAS_HDF5)
                 using io_t = PartitionIO<_mesh_type>;
                 std::string fnamePartitioned = rebuild_partitions_filename;
                 if ( fnamePartitioned.empty() )
@@ -162,6 +162,7 @@ BOOST_PARAMETER_FUNCTION(
                 io_t io( fname );
                 std::vector<elements_reference_wrapper_t<_mesh_type>> partitionByRange;
                 io.write( partitionMesh( _meshSeq, partitions, partitionByRange ) );
+#endif
             }
             else
             {
@@ -172,13 +173,13 @@ BOOST_PARAMETER_FUNCTION(
                 _mesh->updateForUse();
             }
         }
-
+#if defined(FEELPP_HAS_HDF5)
         if ( partitions > 1 )
         {
             mpi::broadcast( worldcomm->globalComm(), fname, worldcomm->masterRank() );
             _mesh->loadHDF5( fname, update, scale );
         }
-
+#endif
         if ( straighten && _mesh_type::nOrder > 1 )
             return straightenMesh( _mesh, worldcomm->subWorldCommPtr() );
     }

--- a/feelpp/feel/feelfilters/importergmsh.cpp
+++ b/feelpp/feel/feelfilters/importergmsh.cpp
@@ -125,7 +125,12 @@ int getInfoMSH(const int typeMSH, std::string & elementName)
 {
     int dim, order, numNodes;
     std::vector<double> parametricCoord;
+#if GMSH_VERSION_LESS_THAN( 4,4,2 )
     gmsh::model::mesh::getElementProperties( typeMSH,elementName,dim,order,numNodes,parametricCoord );
+#else
+    int numPrimaryNodes;
+    gmsh::model::mesh::getElementProperties( typeMSH,elementName,dim,order,numNodes,parametricCoord,numPrimaryNodes );
+#endif
     return numNodes;
 }
 #else


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [ ] Have you successfully run the Feel++ testsuite with your changes locally?
- [ ] Have you written Doxygen comments in your contribution ?

-----
There are still many compilation failures, e.g.,
```
feelpp/feelpp/feel/../feel/feeldiscr/functionspace.hpp:4658:53: note: passing argument to parameter 'worldscomm' here
                                 worldscomm_ptr_t & worldscomm = Environment::worldsComm(nSpaces),
                                                    ^
feelpp/feelpp/feel/../feel/feeldiscr/functionspace.hpp:4653:56: error: binding value of type 'const vector<...>' to reference to
      type 'vector<...>' drops 'const' qualifier
        return NewImpl( mesh, cms.M_meshSupportVector, worldscomm, components, periodicity, edt );
```
or
```
feelpp/feelpp/feel/../feel/feelvf/projectors.hpp:265:1: note: candidate template ignored: could not match 'Expr' against 'tuple'
project_impl( std::shared_ptr<FunctionSpaceType> const& __functionspace,
^
feelpp/feelpp/feel/../feel/feelvf/projectors.hpp:424:12: error: no matching function for call to 'project_impl'
    return project_impl( space, range, expr, geomap );
```
Feel++ is not supposed to be built on macOS with clang++?