### PR TITLE
fix test_exprevaluator in parallel @vincentchabannes

### DIFF
--- a/testsuite/feelvf/test_exprevaluator.cpp
+++ b/testsuite/feelvf/test_exprevaluator.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE( test_1 )
     auto ee = ExpressionEvaluatorNonLinear<decltype(r), decltype(ex), decltype(u)>( r, ex, mu, u);
     ee.init(5);
     ee.update(mu);
-    double res0 = 0., res1 = 0.;
+    double res0 = 0., res1 = 0., res0loc = 0., res1loc = 0.;
     for( auto const& eltWrap : elements(mesh) )
     {
         auto const& elt = unwrap_ref( eltWrap );
@@ -43,10 +43,12 @@ BOOST_AUTO_TEST_CASE( test_1 )
         ee.update( eltWrap );
         for ( uint16_type q = 0; q < ee.nPoints(); ++q )
         {
-            res0 += ee.weight(q)*ee.eval(q, 0);
-            res1 += ee.weight(q)*ee.eval(q, 1);
+            res0loc += ee.weight(q)*ee.eval(q, 0);
+            res1loc += ee.weight(q)*ee.eval(q, 1);
         }
     }
+    mpi::all_reduce(Environment::worldComm().globalComm(), res0loc, res0, std::plus<double>());
+    mpi::all_reduce(Environment::worldComm().globalComm(), res1loc, res1, std::plus<double>());
     auto s0 = integrate(_range=elements(mesh), _expr=inner(ex,vec(cst(1.),cst(0.))) ).evaluate()(0,0);
     auto s1 = integrate(_range=elements(mesh), _expr=inner(ex,vec(cst(0.),cst(1.))) ).evaluate()(0,0);
     BOOST_CHECK_CLOSE(res0, s0, 1e-10);


### PR DESCRIPTION
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [ ] Have you successfully run the Feel++ testsuite with your changes locally?
- [ ] Have you written Doxygen comments in your contribution ?

-----
The test pass in sequential and in parallel now:
```
Test project /ssd/hild/builds/develop_rel/testsuite/feelvf
    Start 47: feelpp_test_exprevaluator-np-6
1/2 Test #47: feelpp_test_exprevaluator-np-6 ...   Passed    4.11 sec
    Start 48: feelpp_test_exprevaluator-np-1
2/2 Test #48: feelpp_test_exprevaluator-np-1 ...   Passed    3.91 sec

100% tests passed, 0 tests failed out of 2
```