### PR TITLE
Feature/distancetorange

### DIFF
--- a/feelpp/feel/feells/distancetorange.hpp
+++ b/feelpp/feel/feells/distancetorange.hpp
@@ -37,6 +37,7 @@
 #include <feel/feells/fastmarching_impl.hpp>
 #include <feel/feelmesh/filters.hpp>
 #include <feel/feeldiscr/syncdofs.hpp>
+#include <feel/feelcore/traits.hpp>
 
 #include "geometryconceptwrappers.hpp"
 #include "distancepointtoface.hpp"
@@ -410,6 +411,14 @@ DistanceToRange< FunctionSpaceType >::dofsNeighbouringFaces( range_faces_type co
     }
 
     return M_dofsNeighbouringFaces;
+}
+
+template< typename SpaceType, typename RangeType >
+typename Feel::decay_type<SpaceType>::element_type
+distanceToRange( SpaceType const& space, RangeType const& range )
+{
+    DistanceToRange distToRange( space );
+    return distToRange.unsignedDistance( range );
 }
 
 } // namespace Feel

--- a/feelpp/feel/feells/distancetorange.hpp
+++ b/feelpp/feel/feells/distancetorange.hpp
@@ -77,8 +77,6 @@ class DistanceToRange
 
         //--------------------------------------------------------------------//
         // Fast-marching
-        //typedef ReinitializerFMS< functionspace_distance_type > fastmarching_type;
-        //typedef std::shared_ptr<fastmarching_type> fastmarching_ptrtype;
         typedef FastMarching<functionspace_distance_type> fastmarching_type;
         typedef std::shared_ptr< fastmarching_type > fastmarching_ptrtype;
 
@@ -245,7 +243,6 @@ DistanceToRange< FunctionSpaceType >::unsignedDistanceToFaces( range_faces_type 
         );
 
     // Then perform fast-marching
-    //unsignedDistance = this->fastMarching()->march( unsignedDistance, rangeEltsTouchingFaces );
     unsignedDistance = this->fastMarching()->run( unsignedDistance, rangeEltsTouchingFaces );
     // Return
     return unsignedDistance;

--- a/feelpp/feel/feells/distancetorange.hpp
+++ b/feelpp/feel/feells/distancetorange.hpp
@@ -33,7 +33,6 @@
 
 #include <feel/feelcore/feel.hpp>
 #include <feel/feeldiscr/functionspace.hpp>
-#include <feel/feells/reinit_fms_impl.hpp>
 #include <feel/feells/fastmarching_impl.hpp>
 #include <feel/feelmesh/filters.hpp>
 #include <feel/feeldiscr/syncdofs.hpp>

--- a/feelpp/feel/feells/distancetorange.hpp
+++ b/feelpp/feel/feells/distancetorange.hpp
@@ -1,0 +1,362 @@
+//! -*- mode: c++; coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; show-trailing-whitespace: t  -*- vim:fenc=utf-8:ft=cpp:et:sw=4:ts=4:sts=4
+//!
+//! This file is part of the Feel++ library
+//!
+//! Author(s) : 
+//!     Thibaut Metivet <thibaut.metivet@inria.fr>
+//!
+//! This library is free software; you can redistribute it and/or
+//! modify it under the terms of the GNU Lesser General Public
+//! License as published by the Free Software Foundation; either
+//! version 2.1 of the License, or (at your option) any later version.
+//!
+//! This library is distributed in the hope that it will be useful,
+//! but WITHOUT ANY WARRANTY; without even the implied warranty of
+//! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//! Lesser General Public License for more details.
+//!
+//! You should have received a copy of the GNU Lesser General Public
+//! License along with this library; if not, write to the Free Software
+//! Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//!
+//! @file distancetomesh.hpp
+//! @author Thibaut Metivet <thibaut.metivet@inria.fr>
+//! @date 01 Sept 2021
+//! @copyright 2021 Feel++ Consortium
+//! @copyright 2021 INRIA
+//!
+
+#ifndef _DISTANCE_TO_RANGE_HPP
+#define _DISTANCE_TO_RANGE_HPP 1
+
+#include <algorithm>
+
+#include <feel/feelcore/feel.hpp>
+#include <feel/feeldiscr/functionspace.hpp>
+#include <feel/feells/reinit_fms_impl.hpp>
+#include <feel/feells/fastmarching_impl.hpp>
+#include <feel/feelmesh/filters.hpp>
+#include <feel/feeldiscr/syncdofs.hpp>
+
+#include "geometryconceptwrappers.hpp"
+#include "distancepointtoface.hpp"
+
+namespace Feel {
+
+template< typename FunctionSpaceType >
+class DistanceToRange
+{
+    public:
+        typedef DistanceToRange< FunctionSpaceType > self_type;
+        typedef std::shared_ptr< self_type > self_ptrtype;
+
+        //--------------------------------------------------------------------//
+        // Distance functionspace and mesh
+        typedef FunctionSpaceType functionspace_distance_type;
+        typedef std::shared_ptr< functionspace_distance_type > functionspace_distance_ptrtype;
+        typedef typename functionspace_distance_type::element_type element_distance_type;
+        typedef typename functionspace_distance_type::element_ptrtype element_distance_ptrtype;
+
+        static const uint16_type nDofPerEltDistance = functionspace_distance_type::fe_type::nDof;
+
+        typedef typename functionspace_distance_type::mesh_type mesh_distance_type;
+        typedef typename functionspace_distance_type::mesh_ptrtype mesh_distance_ptrtype;
+
+        typedef typename MeshTraits<mesh_distance_type>::elements_reference_wrapper_type elements_reference_wrapper_distance_type;
+        typedef typename MeshTraits<mesh_distance_type>::elements_reference_wrapper_ptrtype elements_reference_wrapper_distance_ptrtype;
+        typedef elements_reference_wrapper_t<mesh_distance_type> range_elements_distance_type;
+
+        typedef faces_reference_wrapper_t<mesh_distance_type> range_faces_type;
+
+        //--------------------------------------------------------------------//
+        static constexpr uint16_type nRealDim = functionspace_distance_type::nRealDim;
+        using size_type = typename functionspace_distance_type::size_type;
+        typedef typename functionspace_distance_type::value_type value_type;
+        typedef typename node<value_type>::type node_type;
+        typedef typename matrix_node<value_type>::type matrix_node_type;
+
+        //--------------------------------------------------------------------//
+        // Fast-marching
+        //typedef ReinitializerFMS< functionspace_distance_type > fastmarching_type;
+        //typedef std::shared_ptr<fastmarching_type> fastmarching_ptrtype;
+        typedef FastMarching<functionspace_distance_type> fastmarching_type;
+        typedef std::shared_ptr< fastmarching_type > fastmarching_ptrtype;
+
+    public:
+        //--------------------------------------------------------------------//
+        // Constructor
+        DistanceToRange( functionspace_distance_ptrtype const& spaceDistance );
+
+        //--------------------------------------------------------------------//
+        // Accessors
+        functionspace_distance_ptrtype const& functionSpaceDistance() const { return M_spaceDistance; }
+        mesh_distance_ptrtype const& meshDistance() const { return this->functionSpaceDistance()->mesh(); }
+
+        //--------------------------------------------------------------------//
+        // Fast-marching
+        fastmarching_ptrtype const& fastMarching() const;
+
+        //--------------------------------------------------------------------//
+        // Geometry
+        value_type distanceDofToFace( size_type dofId, size_type faceId ) const;
+
+        //--------------------------------------------------------------------//
+        // Result
+        template< typename RangeType >
+        element_distance_type unsignedDistance( RangeType const& rangeFaces ) const;
+        template< typename RangeType >
+        element_distance_type signedDistance( RangeType const& rangeFaces ) const;
+
+    private:
+        element_distance_type unsignedDistanceToFaces( range_faces_type const& rangeFaces ) const;
+        element_distance_type signedDistanceToFaces( range_faces_type const& rangeFaces ) const;
+
+    private:
+        functionspace_distance_ptrtype M_spaceDistance;
+
+        fastmarching_ptrtype M_fastMarching;
+
+        mutable std::unordered_map< size_type, Eigen::Matrix<value_type,3,3> > M_faceTriangleTransformationMatrices;
+};
+
+template< typename FunctionSpaceType >
+DistanceToRange< FunctionSpaceType >::DistanceToRange(
+        functionspace_distance_ptrtype const& spaceDistance ) :
+    M_spaceDistance( spaceDistance )
+{}
+
+template< typename FunctionSpaceType >
+typename DistanceToRange< FunctionSpaceType >::fastmarching_ptrtype const&
+DistanceToRange< FunctionSpaceType >::fastMarching() const
+{
+    if( !M_fastMarching )
+        const_cast<self_type*>(this)->M_fastMarching.reset( new fastmarching_type( this->functionSpaceDistance() ) );
+
+    return M_fastMarching;
+}
+
+template< typename FunctionSpaceType >
+typename DistanceToRange< FunctionSpaceType >::value_type 
+DistanceToRange< FunctionSpaceType >::distanceDofToFace( size_type dofId, size_type faceId ) const
+{
+    auto const& face = this->meshDistance()->face( faceId );
+    auto const& pt = boost::get<0>( this->functionSpaceDistance()->dof()->dofPoint( dofId ) );
+    auto const& faceVertices = face.vertices();
+
+    auto P = eigenMap<nRealDim>( pt );
+    auto F = eigenMap<nRealDim>( faceVertices );
+
+    if constexpr ( nRealDim == 2 )
+    {
+        return Feel::detail::geometry::distancePointToSegment( P, F.col(0), F.col(1) );
+    }
+    else if constexpr ( nRealDim == 3 )
+    {
+        auto const& P1 = F.col(0);
+        auto const& P2 = F.col(1);
+        auto const& P3 = F.col(2);
+        auto surfaceTriangleTransformationMatrixIt = M_faceTriangleTransformationMatrices.find( faceId );
+        if( surfaceTriangleTransformationMatrixIt == M_faceTriangleTransformationMatrices.end() ) 
+        {
+            surfaceTriangleTransformationMatrixIt = M_faceTriangleTransformationMatrices.insert( { faceId, Feel::detail::geometry::triangleFrameTransformationMatrix( P1, P2, P3 ) } ).first;
+        }
+        return Feel::detail::geometry::distancePointToTriangleWithTransformationMatrix( P, P1, P2, P3, surfaceTriangleTransformationMatrixIt->second );
+    }
+}
+
+template< typename FunctionSpaceType >
+template< typename RangeType >
+typename DistanceToRange< FunctionSpaceType >::element_distance_type
+DistanceToRange< FunctionSpaceType >::unsignedDistance( RangeType const& rangeFaces ) const
+{
+    return this->unsignedDistanceToFaces( rangeFaces );
+}
+
+template< typename FunctionSpaceType >
+template< typename RangeType >
+typename DistanceToRange< FunctionSpaceType >::element_distance_type
+DistanceToRange< FunctionSpaceType >::signedDistance( RangeType const& rangeFaces ) const
+{
+    return this->signedDistanceToFaces( rangeFaces );
+}
+
+template< typename FunctionSpaceType >
+typename DistanceToRange< FunctionSpaceType >::element_distance_type
+DistanceToRange< FunctionSpaceType >::unsignedDistanceToFaces( range_faces_type const& rangeFaces ) const
+{
+    auto unsignedDistance = this->functionSpaceDistance()->element( "unsignedDistance" );
+    // Initialise distance with arbitrarily large value
+    //unsignedDistance->setConstant( std::numeric_limits<value_type>::max() );
+    unsignedDistance.setConstant(1e8);
+    // Compute exact distance on touching elements
+    auto const& dofTable = this->functionSpaceDistance()->dof();
+    auto const computeDistanceToFaceOnElt = [ & ] ( size_type const faceId, size_type const eltId )
+    {
+        for( uint16_type j = 0; j < nDofPerEltDistance; j++ )
+        {
+            size_type const eltDofGlobalId = dofTable->localToGlobal( eltId, j, 0 ).index();
+
+            auto dist = this->distanceDofToFace( eltDofGlobalId, faceId );
+            if( dist < unsignedDistance.localToGlobal( eltId, j, 0 ) )
+                unsignedDistance.assign( eltId, j, 0, dist );
+        }
+    };
+
+    elements_reference_wrapper_distance_ptrtype eltsTouchingFaces( new elements_reference_wrapper_distance_type );
+
+    auto face_it = rangeFaces.template get<1>();
+    auto face_en = rangeFaces.template get<2>();
+    for( ; face_it != face_en ; ++face_it )
+    {
+        auto const& face = boost::unwrap_ref( *face_it );
+        size_type const faceId = face.id();
+        if ( face.isConnectedTo0() )
+        {
+            eltsTouchingFaces->push_back( boost::cref( face.element0() ) );
+            computeDistanceToFaceOnElt( faceId, face.element0().id() );
+        }
+        if ( face.isConnectedTo1() )
+        {
+            eltsTouchingFaces->push_back( boost::cref( face.element1() ) );
+            computeDistanceToFaceOnElt( faceId, face.element1().id() );
+        }
+    }
+    eltsTouchingFaces->shrink_to_fit();
+    range_elements_distance_type rangeEltsTouchingFaces( mpl::size_t<MESH_ELEMENTS>(), eltsTouchingFaces->begin(), eltsTouchingFaces->end(), eltsTouchingFaces );
+
+    // Sync initial distance
+    syncDofs( unsignedDistance, rangeEltsTouchingFaces,
+            []( value_type valCurrent, std::set<value_type> ghostVals )
+            {
+                auto const minGhostValueIt = std::min_element( ghostVals.begin(), ghostVals.end() );
+                return std::min( valCurrent, *minGhostValueIt );
+            }
+        );
+
+    // Then perform fast-marching
+    //unsignedDistance = this->fastMarching()->march( unsignedDistance, rangeEltsTouchingFaces );
+    unsignedDistance = this->fastMarching()->run( unsignedDistance, rangeEltsTouchingFaces );
+    sync( unsignedDistance, "min" );
+    // Return
+    return unsignedDistance;
+}
+
+template< typename FunctionSpaceType >
+typename DistanceToRange< FunctionSpaceType >::element_distance_type
+DistanceToRange< FunctionSpaceType >::signedDistanceToFaces( range_faces_type const& rangeFaces ) const
+{
+    // Compute unsigned distance
+    // Set sign: set negative everywhere, then propagate + sign from the domain boundary
+    // note: the element container (VectorUblas) does not provide unary operators at the moment -> TODO: need to improve
+    auto signedDistance = this->unsignedDistanceToFaces( rangeFaces );
+    signedDistance->scale( -1. );
+    // Find elements touching the faces
+    // TODO: remove duplicate run with unsignedDistanceToFaces
+    range_elements_distance_type rangeEltsWithFaces = elementsWithFaces( rangeFaces );
+    elements_reference_wrapper_distance_ptrtype eltsWithFaces = rangeEltsWithFaces.template get<3>();
+
+    // Communication
+    rank_type const pidMeshDistance = this->meshDistance()->worldCommPtr()->localRank();
+    std::set<rank_type> const& neighborSubdomainsMeshDistance = this->meshDistance()->neighborSubdomains();
+    int nRequests = 2*neighborSubdomainsMeshDistance.size();
+    mpi::request * mpiRequests = new mpi::request[nRequests];
+
+    std::unordered_set< size_type > eltsToVisit, eltsVisited;
+    auto const& intersectingElements = this->intersectingElements();
+    auto const rangeMeshBoundaryElements = boundaryelements( this->meshDistance() );
+    auto it_boundaryelt = rangeMeshBoundaryElements.template get<1>();
+    auto en_boundaryelt = rangeMeshBoundaryElements.template get<2>();
+    for( ; it_boundaryelt != en_boundaryelt; it_boundaryelt++ )
+    {
+        auto const& elt = boost::unwrap_ref( *it_boundaryelt );
+        size_type const eltId = elt.id();
+        eltsToVisit.insert( eltId );
+    }
+
+    bool eltsToVisitIsEmptyOnAllProc = false;
+    while( !eltsToVisitIsEmptyOnAllProc )
+    {
+        /* Contain the ghost elts which require communication */
+        std::map<rank_type, std::vector< size_type > > dataToRecv;
+        std::map<rank_type, std::vector< size_type > > dataToSend;
+
+        while( !eltsToVisit.empty() )
+        {
+            auto eltIt = eltsToVisit.begin();
+            size_type eltId = *eltIt;
+            auto const& elt = this->meshDistance()->element( eltId );
+            // visit elt
+            // set + sign
+            for( uint16_type j = 0; j < nDofPerEltDistance; j++ )
+            {
+                auto curPhi = signedDistance.localToGlobal( eltId, j, 0 );
+                if( curPhi < 0. )
+                    signedDistance.assign( eltId, j, 0, -curPhi );
+            }
+            // add potential neighbors to visit
+            for( uint16_type faceId = 0; faceId < elt.nTopologicalFaces(); faceId++ )
+            {
+                size_type neighId = elt.neighbor( faceId );
+                if( neighId == invalid_size_type_value )
+                    continue;
+                auto const& neigh = this->meshDistance()->element( neighId );
+                rank_type const neighPid = neigh.processId();
+                // the neighbor elt is a ghost -> send to owner
+                if( neighPid != pidMeshDistance )
+                {
+                    size_type neighIdOnOwner = neigh.idInOthersPartitions( neighPid );
+                    dataToSend[neighPid].push_back( neighIdOnOwner );
+                    continue;
+                }
+                if( eltsVisited.find( neighId ) != eltsVisited.end()
+                        // stop when reaching an intersecting elt
+                        || intersectingElements.find( neighId ) != intersectingElements.end() )
+                    continue;
+                // need to visit neighbor
+                eltsToVisit.insert( neighId );
+            }
+            eltsVisited.insert( eltId );
+            eltsToVisit.erase( eltIt );
+        }
+
+        // Perform communications
+        int cntRequests = 0;
+        for( rank_type neighborRank: neighborSubdomainsMeshDistance )
+        {
+            mpiRequests[cntRequests++] = this->meshDistance()->worldCommPtr()->localComm().isend( neighborRank, 0, dataToSend[neighborRank] );
+            mpiRequests[cntRequests++] = this->meshDistance()->worldCommPtr()->localComm().irecv( neighborRank, 0, dataToRecv[neighborRank] );
+        }
+        mpi::wait_all( mpiRequests, mpiRequests + cntRequests );
+
+        /* Process received ghosts */
+        for( auto const& data: dataToRecv )
+        {
+            for( size_type const eltId: data.second )
+            {
+                if( eltsVisited.find( eltId ) != eltsVisited.end()
+                        // stop when reaching an intersecting elt
+                        || eltsWithFaces->find( eltId ) != intersectingElements.end() )
+                    continue;
+                // need to visit neighbor
+                eltsToVisit.insert( eltId );
+            }
+        }
+
+        bool eltsToVisitIsEmpty = eltsToVisit.empty();
+        eltsToVisitIsEmptyOnAllProc = mpi::all_reduce(
+                this->meshDistance()->worldComm(),
+                eltsToVisitIsEmpty,
+                std::logical_and<bool>() );
+    }
+
+    delete [] mpiRequests;
+
+    sync( signedDistance, "max" );
+
+    // Return
+    return signedDistance;
+}
+
+} // namespace Feel
+
+#endif //_DISTANCE_TO_RANGE_HPP

--- a/testsuite/feells/CMakeLists.txt
+++ b/testsuite/feells/CMakeLists.txt
@@ -29,3 +29,5 @@ endforeach()
 foreach(TEST extender_from_interface )
     feelpp_add_test( ${TEST} NO_MPI_TEST )
 endforeach()
+
+feelpp_add_test( distancetorange )

--- a/testsuite/feells/test_distancetorange.cpp
+++ b/testsuite/feells/test_distancetorange.cpp
@@ -1,0 +1,166 @@
+/* -*- mode: c++; coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; show-trailing-whitespace: t  -*-
+
+ This file is part of the Feel++ library
+
+ Author(s): Thibaut Metivet <thibaut.metivet@inria.fr>
+ Date: 13 Sept 2021
+
+ Copyright (C) 2021 Feel++ Consortium
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#define BOOST_TEST_MODULE test distance
+
+#include <feel/feelcore/testsuite.hpp>
+#include <boost/hana/integral_constant.hpp>
+#include <fmt/core.h>
+
+#include <feel/feeldiscr/mesh.hpp>
+#include <feel/feeldiscr/pch.hpp>
+#include <feel/feelfilters/loadmesh.hpp>
+#include <feel/feelfilters/unitsquare.hpp>
+#include <feel/feelfilters/unitcube.hpp>
+#include <feel/feelfilters/exporter.hpp>
+#include <feel/feells/distancetorange.hpp>
+
+using namespace Feel;
+namespace hana =  boost::hana;
+using namespace hana::literals;
+
+inline
+po::options_description
+makeOptions()
+{
+    po::options_description desc_options( "test_distancetorange options" );
+    desc_options.add_options()
+        ( "hsize", po::value<double>()->default_value( 0.1 ), "mesh size" )
+        ( "remesh.verbose", po::value<int>()->default_value( 1 ), "mesh size" )
+        ( "remesh.hmin", po::value<double>(), "Minimal mesh size " )
+        ( "remesh.hmax", po::value<double>(), "Maximal mesh size " )
+        ( "remesh.hsiz", po::value<double>(), "Constant mesh size " )
+        
+        ;
+    return desc_options.add( Feel::feel_options() );
+}
+
+/*_________________________________________________*
+ * About
+ *_________________________________________________*/
+
+inline
+AboutData
+makeAbout()
+{
+    AboutData about( "test_distancetorange" ,
+                     "test_distancetorange" ,
+                     "0.1",
+                     "test DistanceToRange",
+                     Feel::AboutData::License_GPL,
+                     "Copyright (c) 2021 Feel++ Consortium" );
+
+    about.addAuthor( "Thibaut Metivet", "developer", "thibaut.metivet@inria.fr", "" );
+    return about;
+}
+
+
+/**
+ * @brief test DistanceToRange with various options
+ * 
+ * \tparam Dim dimension
+ */
+template<uint16_type Dim, uint16_type Order>
+class TestDistanceToRange
+{
+    public:
+        using mesh_type = Mesh<Simplex<Dim>>;
+        using mesh_ptrtype = std::shared_ptr< mesh_type >;
+        
+        TestDistanceToRange() = default;
+
+        mesh_ptrtype setMesh( std::string const& fname = "" );
+        mesh_ptrtype const& mesh() const { return M_mesh; }
+
+        int run();
+
+    private:
+        mesh_ptrtype M_mesh;
+};
+
+template<uint16_type Dim, uint16_type Order>
+typename TestDistanceToRange<Dim, Order>::mesh_ptrtype 
+TestDistanceToRange<Dim, Order>::setMesh( std::string const& filename )
+{
+    auto create_mesh = [&]() {
+        if constexpr ( Dim == 2 )
+        {
+            if ( filename.empty() )
+                return unitSquare();
+            else
+                return loadMesh( _mesh = new Mesh<Simplex<2>>( "mesh" ), _filename = filename );
+        }
+        else if constexpr ( Dim == 3 )
+        {
+            if ( filename.empty() )
+                return unitCube();
+            else
+                return loadMesh( _mesh = new Mesh<Simplex<3, 1>>( "mesh" ), _filename = filename );
+        }
+    };
+    M_mesh = create_mesh();
+    return M_mesh;
+}
+
+template<uint16_type Dim, uint16_type Order>
+int
+TestDistanceToRange<Dim, Order>::run()
+{
+    if( !M_mesh )
+        this->setMesh();
+    auto const& mesh = this->mesh();
+    auto Vh = Pch<Order>( mesh );
+
+    // Exporter
+    auto exp = exporter( _mesh = mesh, _name = fmt::format( "distance_{}d_o{}", Dim, Order ) );
+    exp->addRegions();
+
+    // Distance to boundary
+    auto distToBoundary = distanceToRange( Vh, boundaryfaces( mesh ) );
+    exp->add( "distToBoundary", distToBoundary );
+
+    // Export
+    exp->save();
+
+    return 1;
+}
+
+FEELPP_ENVIRONMENT_WITH_OPTIONS( makeAbout(), makeOptions() )
+
+
+BOOST_AUTO_TEST_SUITE( distance )
+
+typedef boost::mpl::list< boost::mpl::int_<2>, boost::mpl::int_<3> > dim_types;
+//typedef boost::mpl::list< boost::mpl::int_<2> > dim_types;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE( testnD, T, dim_types )
+{
+    using namespace Feel;
+
+    TestDistanceToRange<T::value, 1> test;
+    test.setMesh();
+    test.run();
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adds support for the computation of the distance to a range of faces using exact distance initialisation and first-order parallel fast-marching. The distance can be simply obtained using the helper function
`distanceToRange( Xh, rangeFaces )`
with `Xh` a functionspace and `rangeFaces` the range considered (e.g. `boundaryelements(mesh)`). Additional functionalities can be accessed using the class `DistanceToRange`.

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes?
- [x] Have you successfully run the Feel++ testsuite with your changes locally?
-----
