### PR TITLE
fix toc display for crb code

### DIFF
--- a/feelpp/feel/feeltiming/tic.hpp
+++ b/feelpp/feel/feeltiming/tic.hpp
@@ -49,10 +49,11 @@ struct FEELPP_NO_EXPORT SecondBasedTimer
     {
         if ( Environment::isMasterRank() )
         {
+            int cols = (val.second < 15) ? val.second : 15;
             if ( !msg.empty() )
-                std::cout << std::setw(1+val.second) << "[" << msg << "] Time : " << val.first << "s\n";
+                std::cout << std::setw(1+cols) << "[" << msg << "] Time : " << val.first << "s\n";
             else
-                std::cout << std::setw(7+val.second) << "Time : " << val << "s\n";
+                std::cout << std::setw(7+cols) << "Time : " << val << "s\n";
         }
     }
     static inline time_point  time()

--- a/mor/mor/feel/feelmor/crb.hpp
+++ b/mor/mor/feel/feelmor/crb.hpp
@@ -5773,19 +5773,18 @@ CRB<TruthModelType>::fixedPoint(  size_type N, parameter_type const& mu, std::ve
                                   std::vector<vectorN_type> & uNold, std::vector<vectorN_type> & uNduold,
                                   std::vector< double > & output_vector, int K, bool print_rb_matrix, bool computeOutput ) const
 {
-    double t;
     matrix_info_tuple matrix_info;
     tic();
     matrix_info = fixedPointPrimal( N, mu , uN , uNold, output_vector, K , print_rb_matrix, computeOutput ) ;
-    t = toc("CRB::fixedPoint() : fixedPointPrimal", false);
-    VLOG(3) << fmt::format("CRB::fixedPoint() : fixedPointPrimal took {} seconds", t);
+    double t_fp = toc("CRB::fixedPoint() : fixedPointPrimal", false);
+    VLOG(3) << fmt::format("CRB::fixedPoint() : fixedPointPrimal took {} seconds", t_fp);
 
     if( M_solve_dual_problem )
     {
         tic();
         fixedPointDual( N, mu , uN, uNdu , uNduold , output_vector , K ) ;
-        t = toc("CRB::fixedPoint() : fixedPointDual", false);
-        VLOG(3) << fmt::format("CRB::fixedPoint() : fixedPointDual took {} seconds", t);
+        double t_fd = toc("CRB::fixedPoint() : fixedPointDual", false);
+        VLOG(3) << fmt::format("CRB::fixedPoint() : fixedPointDual took {} seconds", t_fd);
 
         if ( computeOutput )
         {
@@ -5813,8 +5812,8 @@ CRB<TruthModelType>::fixedPoint(  size_type N, parameter_type const& mu, std::ve
                     ++time_index;
                 }
             }
-            t = toc("CRB::fixedPoint() : correctionTerms", false);
-            VLOG(3) << fmt::format("CRB::fixedPoint() : correctionTerms took {} seconds", t);
+            double t_fp = toc("CRB::fixedPoint() : correctionTerms", false);
+            VLOG(3) << fmt::format("CRB::fixedPoint() : correctionTerms took {} seconds", t_fp);
         }
     }
 
@@ -9484,11 +9483,10 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
         Nwn = M_N;
     }
     Feel::Timer t1;
-    double t;
     tic();
     auto o = lb( Nwn, mu, uN, uNdu , uNold, uNduold , print_rb_matrix);
-    t = toc("[CRB::run] lb", false);
-    VLOG(3) << fmt::format("[CRB::run] lb = {}", t);
+    double t_run = toc("[CRB::run] lb", false);
+    VLOG(3) << fmt::format("[CRB::run] lb = {}", t_run);
 
     double time_prediction=t1.elapsed();
     auto output_vector=o.template get<0>();
@@ -9497,7 +9495,7 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
     t1.start();
     tic();
     auto error_estimation = delta( Nwn, mu, uN, uNdu , uNold, uNduold );
-    t = toc("[CRB::run] delta", false);
+    double t = toc("[CRB::run] delta", false);
     VLOG(3) << fmt::format("[CRB::run] delta = {}", t);
 
     double time_error_estimation=t1.elapsed();
@@ -9532,12 +9530,12 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
     }
     tic();
     double delta_pr = error_estimation.template get<3>();
-    t = toc("[CRB::run] delta_pr", false);
-    VLOG(3) << fmt::format("[CRB::run] delta_pr = {}", t);
+    double t_pr = toc("[CRB::run] delta_pr", false);
+    VLOG(3) << fmt::format("[CRB::run] delta_pr = {}", t_pr);
     tic();
     double delta_du = error_estimation.template get<4>();
-    t = toc("[CRB::run] delta_du", false);
-    VLOG(3) << fmt::format( "[CRB::run] delta_du = {}", t );
+    double t_du = toc("[CRB::run] delta_du", false);
+    VLOG(3) << fmt::format("[CRB::run] delta_du = {}", t_du);
 
     time.resize(2);
     time(0)=time_prediction;

--- a/mor/mor/feel/feelmor/crb.hpp
+++ b/mor/mor/feel/feelmor/crb.hpp
@@ -634,8 +634,8 @@ public:
 
         }
     /**
-     * @brief Set the Output Name 
-     * 
+     * @brief Set the Output Name
+     *
      * @param oname name of the outout
      */
     void setOutputName( std::string const& oname )
@@ -2776,7 +2776,7 @@ CRB<TruthModelType>::offline()
             LOG(INFO)<<"[CRB::offline] start of POD \n";
 
             pod_ptrtype POD = pod_ptrtype( new pod_type(  ) );
-            bool POD_WN = boption(_prefix=M_prefix,_name="crb.apply-POD-to-WN") ;
+            bool POD_WN = boption(_prefix=M_prefix, _name="crb.apply-POD-to-WN");
 
             if ( seek_mu_in_complement ) // M_mode_number == 1 )
             {
@@ -5776,13 +5776,13 @@ CRB<TruthModelType>::fixedPoint(  size_type N, parameter_type const& mu, std::ve
     matrix_info_tuple matrix_info;
     tic();
     matrix_info = fixedPointPrimal( N, mu , uN , uNold, output_vector, K , print_rb_matrix, computeOutput ) ;
-    VLOG(3) << fmt::format("CRB::fixedPoint() : fixedPointPrimal took {} seconds",toc("CRB::fixedPoint() : fixedPointPrimal"));
+    LOG(INFO) << fmt::format("CRB::fixedPoint() : fixedPointPrimal took {} seconds", toc("CRB::fixedPoint() : fixedPointPrimal", false));
 
     if( M_solve_dual_problem )
     {
         tic();
         fixedPointDual( N, mu , uN, uNdu , uNduold , output_vector , K ) ;
-        VLOG(3) << fmt::format("CRB::fixedPoint() : fixedPointDual took {} seconds",toc("CRB::fixedPoint() : fixedPointDual"));
+        LOG(INFO) << fmt::format("CRB::fixedPoint() : fixedPointDual took {} seconds", toc("CRB::fixedPoint() : fixedPointDual", false));
 
         if ( computeOutput )
         {
@@ -5804,13 +5804,13 @@ CRB<TruthModelType>::fixedPoint(  size_type N, parameter_type const& mu, std::ve
                 double prevcorrection = 0;
                 for ( double time=0; math::abs(time-time_for_output-time_step)>1e-9; time+=time_step )
                 {
-                    double curcorrection = correctionTerms(mu, uN , uNdu, uNold, time_index, prevcorrection );
+                    double curcorrection = correctionTerms(mu, uN , uNdu, uNold, time_index, prevcorrection);
                     output_vector[time_index]+= curcorrection;
                     prevcorrection = curcorrection;
                     ++time_index;
                 }
             }
-            VLOG(3) << fmt::format("CRB::fixedPoint() : correctionTerms took {} seconds",toc("CRB::fixedPoint() : correctionTerms"));
+            LOG(INFO) << fmt::format("CRB::fixedPoint() : correctionTerms took {} seconds", toc("CRB::fixedPoint() : correctionTerms", false));
         }
     }
 
@@ -5823,7 +5823,7 @@ CRB<TruthModelType>::lb( size_type N, parameter_type const& mu, std::vector< vec
                          std::vector<vectorN_type> & uNold, std::vector<vectorN_type> & uNduold, bool print_rb_matrix, int K,
                          bool computeOutput ) const
 {
-    VLOG(2) << fmt::format("CRB::lb() : Start lb functions with mu={}, N={}, print_rb_matrix={}, K={}, computeOutput={}",mu.toString(),N,print_rb_matrix,K,computeOutput);
+    VLOG(2) << fmt::format("CRB::lb() : Start lb functions with mu={}, N={}, print_rb_matrix={}, K={}, computeOutput={}", mu.toString(), N, print_rb_matrix, K, computeOutput);
     if ( N > M_N ) N = M_N;
 
     int number_of_time_step = M_model->numberOfTimeStep();
@@ -5850,7 +5850,7 @@ CRB<TruthModelType>::lb( size_type N, parameter_type const& mu, std::vector< vec
 
     tic();
     auto matrix_info = onlineSolve( N ,  mu , uN , uNdu , uNold , uNduold , output_vector , K , print_rb_matrix, computeOutput );
-    VLOG(3) << fmt::format("CRB::lb() : onlineSolve took {} seconds",toc("CRB::lb() : onlineSolve"));
+    LOG(INFO) << fmt::format("CRB::lb() : onlineSolve took {} seconds", toc("CRB::lb() : onlineSolve", false));
 
     if ( M_compute_variance || M_save_output_behavior )
     {
@@ -5986,7 +5986,7 @@ CRB<TruthModelType>::delta( size_type N,
         double dual_sum_eim=0;
 
         //vectors to store residual coefficients
-       
+
         primal_residual_coeffs.resize( K );
         dual_residual_coeffs.resize( K );
 
@@ -6009,7 +6009,7 @@ CRB<TruthModelType>::delta( size_type N,
                     boost::tie( alphaM_up, lbti ) = M_scmM->ub( mu );
                 //LOG( INFO ) << "alphaM_lo = " << alphaM << " alphaM_hi = " << alphaM_up ;
             }
-            VLOG(3) << fmt::format("CRB::delta() : scm took {} seconds",toc("CRB::delta() : scm"));
+            LOG(INFO) << fmt::format("CRB::delta() : scm took {} seconds", toc("CRB::delta() : scm", false));
         }
 
         //index associated to the output time
@@ -9480,7 +9480,7 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
     Feel::Timer t1;
     tic();
     auto o = lb( Nwn, mu, uN, uNdu , uNold, uNduold , print_rb_matrix);
-    VLOG(3) << fmt::format( "[CRB::run] lb = {}", toc("[CRB::run] lb") );
+    LOG(INFO) << fmt::format( "[CRB::run] lb = {}", toc("[CRB::run] lb", false) );
 
     double time_prediction=t1.elapsed();
     auto output_vector=o.template get<0>();
@@ -9489,8 +9489,8 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
     t1.start();
     tic();
     auto error_estimation = delta( Nwn, mu, uN, uNdu , uNold, uNduold );
-    VLOG(3) << fmt::format( "[CRB::run] delta = {}", toc("[CRB::run] delta") );
-    
+    LOG(INFO) << fmt::format( "[CRB::run] delta = {}", toc("[CRB::run] delta", false) );
+
     double time_error_estimation=t1.elapsed();
     auto vector_output_upper_bound = error_estimation.template get<0>();
     double output_upper_bound = vector_output_upper_bound[0];
@@ -9523,10 +9523,10 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
     }
     tic();
     double delta_pr = error_estimation.template get<3>();
-    VLOG(3) << fmt::format( "[CRB::run] delta_pr = {}", toc("[CRB::run] delta_pr") );
+    LOG(INFO) << fmt::format( "[CRB::run] delta_pr = {}", toc("[CRB::run] delta_pr", false) );
     tic();
     double delta_du = error_estimation.template get<4>();
-    VLOG(3) << fmt::format( "[CRB::run] delta_du = {}", toc("[CRB::run] delta_du") );
+    LOG(INFO) << fmt::format( "[CRB::run] delta_du = {}", toc("[CRB::run] delta_du", false) );
 
     time.resize(2);
     time(0)=time_prediction;
@@ -9539,8 +9539,8 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
 
     CRBResults r(boost::make_tuple( output_vector , Nwn , solutions, matrix_info , primal_residual_norm , dual_residual_norm, upper_bounds ));
     r.setParameter( mu );
-    VLOG(3) << fmt::format( "[CRB::run] get results = {}", toc("[CRB::run] get results") );
-    VLOG(3) << fmt::format( "[CRB::run] total time = {}", toc("[CRB::run] total time") );
+    LOG(INFO) << fmt::format( "[CRB::run] get results = {}", toc("[CRB::run] get results", false) );
+    LOG(INFO) << fmt::format( "[CRB::run] total time = {}", toc("[CRB::run] total time", false) );
     return r;
 }
 
@@ -11604,7 +11604,7 @@ CRB<TruthModelType>::saveJson()
         // add functionspace file (useful when nproc offline != nproc online)
         std::string functionspaceFilename = fmt::format("{}_functionSpace_p{}.json", this->name(), this->worldComm().size());
         ptreeReducedBasisSpace.add( "functionspace-filename", functionspaceFilename );
-        
+
         ptreeReducedBasisSpace.add( "dimension", M_N );
         if ( M_model && M_model->rBFunctionSpace() && M_model->rBFunctionSpace()->functionSpace() )
         {
@@ -11640,7 +11640,7 @@ CRB<TruthModelType>::saveJson()
                 M_scmM->updatePropertyTree( ptreeParameterScmM );
                 ptree.add_child( "scmM", ptreeParameterScmM );
             }
-        }        
+        }
         write_json( filenameJson, ptree );
     }
 }
@@ -11781,7 +11781,7 @@ CRB<TruthModelType>::setupOfflineFromDB()
                     LOG(INFO) << "Database for basis functions in HDF5 available and loaded";
                 }
             }
-                
+
             auto basis_functions = M_elements_database.wn();
             M_model->rBFunctionSpace()->setBasis( basis_functions );
         }

--- a/mor/mor/feel/feelmor/crb.hpp
+++ b/mor/mor/feel/feelmor/crb.hpp
@@ -5773,16 +5773,19 @@ CRB<TruthModelType>::fixedPoint(  size_type N, parameter_type const& mu, std::ve
                                   std::vector<vectorN_type> & uNold, std::vector<vectorN_type> & uNduold,
                                   std::vector< double > & output_vector, int K, bool print_rb_matrix, bool computeOutput ) const
 {
+    double t;
     matrix_info_tuple matrix_info;
     tic();
     matrix_info = fixedPointPrimal( N, mu , uN , uNold, output_vector, K , print_rb_matrix, computeOutput ) ;
-    LOG(INFO) << fmt::format("CRB::fixedPoint() : fixedPointPrimal took {} seconds", toc("CRB::fixedPoint() : fixedPointPrimal", false));
+    t = toc("CRB::fixedPoint() : fixedPointPrimal", false);
+    VLOG(3) << fmt::format("CRB::fixedPoint() : fixedPointPrimal took {} seconds", t);
 
     if( M_solve_dual_problem )
     {
         tic();
         fixedPointDual( N, mu , uN, uNdu , uNduold , output_vector , K ) ;
-        LOG(INFO) << fmt::format("CRB::fixedPoint() : fixedPointDual took {} seconds", toc("CRB::fixedPoint() : fixedPointDual", false));
+        t = toc("CRB::fixedPoint() : fixedPointDual", false);
+        VLOG(3) << fmt::format("CRB::fixedPoint() : fixedPointDual took {} seconds", t);
 
         if ( computeOutput )
         {
@@ -5810,7 +5813,8 @@ CRB<TruthModelType>::fixedPoint(  size_type N, parameter_type const& mu, std::ve
                     ++time_index;
                 }
             }
-            LOG(INFO) << fmt::format("CRB::fixedPoint() : correctionTerms took {} seconds", toc("CRB::fixedPoint() : correctionTerms", false));
+            t = toc("CRB::fixedPoint() : correctionTerms", false);
+            VLOG(3) << fmt::format("CRB::fixedPoint() : correctionTerms took {} seconds", t);
         }
     }
 
@@ -5850,7 +5854,8 @@ CRB<TruthModelType>::lb( size_type N, parameter_type const& mu, std::vector< vec
 
     tic();
     auto matrix_info = onlineSolve( N ,  mu , uN , uNdu , uNold , uNduold , output_vector , K , print_rb_matrix, computeOutput );
-    LOG(INFO) << fmt::format("CRB::lb() : onlineSolve took {} seconds", toc("CRB::lb() : onlineSolve", false));
+    double t = toc("CRB::lb() : onlineSolve", false);
+    VLOG(3) << fmt::format("CRB::lb() : onlineSolve took {} seconds", t);
 
     if ( M_compute_variance || M_save_output_behavior )
     {
@@ -6009,7 +6014,8 @@ CRB<TruthModelType>::delta( size_type N,
                     boost::tie( alphaM_up, lbti ) = M_scmM->ub( mu );
                 //LOG( INFO ) << "alphaM_lo = " << alphaM << " alphaM_hi = " << alphaM_up ;
             }
-            LOG(INFO) << fmt::format("CRB::delta() : scm took {} seconds", toc("CRB::delta() : scm", false));
+            double t = toc("CRB::delta() : scm", false);
+            VLOG(3) << fmt::format("CRB::delta() : scm took {} seconds", t);
         }
 
         //index associated to the output time
@@ -9478,9 +9484,11 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
         Nwn = M_N;
     }
     Feel::Timer t1;
+    double t;
     tic();
     auto o = lb( Nwn, mu, uN, uNdu , uNold, uNduold , print_rb_matrix);
-    LOG(INFO) << fmt::format( "[CRB::run] lb = {}", toc("[CRB::run] lb", false) );
+    t = toc("[CRB::run] lb", false);
+    VLOG(3) << fmt::format("[CRB::run] lb = {}", t);
 
     double time_prediction=t1.elapsed();
     auto output_vector=o.template get<0>();
@@ -9489,7 +9497,8 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
     t1.start();
     tic();
     auto error_estimation = delta( Nwn, mu, uN, uNdu , uNold, uNduold );
-    LOG(INFO) << fmt::format( "[CRB::run] delta = {}", toc("[CRB::run] delta", false) );
+    t = toc("[CRB::run] delta", false);
+    VLOG(3) << fmt::format("[CRB::run] delta = {}", t);
 
     double time_error_estimation=t1.elapsed();
     auto vector_output_upper_bound = error_estimation.template get<0>();
@@ -9523,10 +9532,12 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
     }
     tic();
     double delta_pr = error_estimation.template get<3>();
-    LOG(INFO) << fmt::format( "[CRB::run] delta_pr = {}", toc("[CRB::run] delta_pr", false) );
+    t = toc("[CRB::run] delta_pr", false);
+    VLOG(3) << fmt::format("[CRB::run] delta_pr = {}", t);
     tic();
     double delta_du = error_estimation.template get<4>();
-    LOG(INFO) << fmt::format( "[CRB::run] delta_du = {}", toc("[CRB::run] delta_du", false) );
+    t = toc("[CRB::run] delta_du", false);
+    VLOG(3) << fmt::format( "[CRB::run] delta_du = {}", t );
 
     time.resize(2);
     time(0)=time_prediction;
@@ -9539,8 +9550,10 @@ CRB<TruthModelType>::run( parameter_type const& mu, vectorN_type & time, double 
 
     CRBResults r(boost::make_tuple( output_vector , Nwn , solutions, matrix_info , primal_residual_norm , dual_residual_norm, upper_bounds ));
     r.setParameter( mu );
-    LOG(INFO) << fmt::format( "[CRB::run] get results = {}", toc("[CRB::run] get results", false) );
-    LOG(INFO) << fmt::format( "[CRB::run] total time = {}", toc("[CRB::run] total time", false) );
+    double t_res = toc("[CRB::run] get results", false);
+    double t_total = toc("[CRB::run] total time", false);
+    LOG(INFO) << fmt::format( "[CRB::run] get results = {}", t_res );
+    LOG(INFO) << fmt::format( "[CRB::run] total time = {}", t_total );
     return r;
 }
 


### PR DESCRIPTION
- ensure that no mor than 15 columns are set in toc call
- do not display online time results in log, while still measuring time
(available in display-stats)

/cc @prudhomm

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run the Feel++ testsuite with your changes locally?
- [ ] Have you written Doxygen comments in your contribution ?

-----
