### PR TITLE
Add PostProcessSave to mixedPoisson for hdg thermoelectric toolbox

### DIFF
--- a/toolboxes/feel/feelmodels/hdg/mixedpoisson.cpp
+++ b/toolboxes/feel/feelmodels/hdg/mixedpoisson.cpp
@@ -364,6 +364,7 @@ MIXEDPOISSON_CLASS_TEMPLATE_TYPE::initPostProcess()
     this->setPostProcessExportsAllFieldsAvailable( {M_potentialKey, M_fluxKey, "post"+M_potentialKey} );
     this->addPostProcessExportsAllFieldsAvailable( this->materialsProperties()->postProcessExportsAllFieldsAvailable( this->mesh(),this->physicsAvailable() ) );
     this->setPostProcessExportsPidName( "pid" );
+    this->setPostProcessSaveAllFieldsAvailable( {M_potentialKey } );
     super_type::initPostProcess();
 
     if ( !this->postProcessExportsFields().empty() )

--- a/toolboxes/feel/feelmodels/hdg/mixedpoisson.hpp
+++ b/toolboxes/feel/feelmodels/hdg/mixedpoisson.hpp
@@ -447,7 +447,7 @@ MixedPoisson<ConvexType, Order, PolySetType, E_Order>::exportResults( double tim
 
     this->executePostProcessExports( M_exporter, time, mfields, symbolsExpr, exportsExpr );
     this->executePostProcessMeasures( time, mfields, symbolsExpr );
-    this->executePostProcessSave( invalid_uint32_type_value, mfields );
+    this->executePostProcessSave( (this->isStationary())? invalid_uint32_type_value : M_bdfPotential->iteration(), mfields );
 
     this->timerTool("PostProcessing").stop("exportResults");
     if ( this->scalabilitySave() )


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [ ] Have you successfully run the Feel++ testsuite with your changes locally?
- [ ] Have you written Doxygen comments in your contribution ?

-----

Adding the option for saving fields as hdf5 in the Post Processing in thermoelectric by adding "setPostProcessSaveAllFieldsAvailable" and "executePostProcessSave" to mixedpoisson