### PR TITLE
2341 smoothstep buge when a negative value of lo is provided

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "editor.tabSize": 4,
     "editor.insertSpaces": true,
+    "diffEditor.ignoreTrimWhitespace": true,
     "files.associations": {
         "iterator": "cpp",
         "*.ipp": "cpp",

--- a/feelpp/contrib/ginac/ginac/parser/default_reader.cpp
+++ b/feelpp/contrib/ginac/ginac/parser/default_reader.cpp
@@ -35,7 +35,7 @@
 namespace GiNaC
 {
 DECLARE_FUNCTION_2P(rand);
-static ex rand_eval(const ex & a,const ex & b) 
+static ex rand_eval(const ex & a,const ex & b)
 {
 	return rand(a,b).hold();
 }
@@ -47,8 +47,8 @@ static void rand_print_latex( const ex& arg1, const ex& arg2, const print_contex
 
 static void rand_print_csrc_float( const ex& arg1, const ex& arg2, const print_context& c )
 {
-    c.s << "[](){ auto [dis, gen] = uniformDistribution("; 
-	arg1.print(c); 
+    c.s << "[](){ auto [dis, gen] = uniformDistribution(";
+	arg1.print(c);
 	c.s << ",";
 	arg2.print( c );
 	c.s << "); return dis(gen); }()";
@@ -168,32 +168,32 @@ REGISTER_FUNCTION( lognormal, eval_func( lognormal_eval ).
 						 print_func<print_csrc_double>( lognormal_print_csrc_float ) );
 
 DECLARE_FUNCTION_2P(mod);
-static ex mod_eval(const ex & x, const ex& y ) 
-{ 
+static ex mod_eval(const ex & x, const ex& y )
+{
 	if (is_exactly_a<numeric>(y) && is_exactly_a<numeric>(x))
 		return mod(ex_to<numeric>(x), ex_to<numeric>(y));
-	
+
 	return mod(x, y).hold();
 }
-static ex mod_evalf(const ex & x, const ex& y ) 
-{ 
+static ex mod_evalf(const ex & x, const ex& y )
+{
 	if (is_exactly_a<numeric>(y) && is_exactly_a<numeric>(x))
 		return mod(ex_to<numeric>(x), ex_to<numeric>(y));
-	
-	return mod(x, y).hold();	
+
+	return mod(x, y).hold();
 }
-                                                                                
+
 static void mod_print_latex(const ex & arg1, const ex&  arg2,const print_context & c)
 {
     c.s << "{"; arg1.print(c); c.s << "\%"; arg2.print(c); c.s << "|}";
 }
-                                                                                
+
 static void mod_print_csrc_float(const ex & arg1, const ex & arg2, const print_context & c)
 {
     c.s << "fmod("; arg1.print(c); c.s << ","; arg2.print(c); c.s << ")";
 }
 
-                                                                                
+
 REGISTER_FUNCTION(mod, eval_func( mod_eval).
                        evalf_func( mod_evalf).
                        print_func<print_latex>( mod_print_latex).
@@ -201,26 +201,26 @@ REGISTER_FUNCTION(mod, eval_func( mod_eval).
                        print_func<print_csrc_double>( mod_print_csrc_float));
 
 DECLARE_FUNCTION_1P(floor);
-static ex floor_eval(const ex & x) 
-{ 
+static ex floor_eval(const ex & x)
+{
 	if (is_exactly_a<numeric>(x))
 		return floor(ex_to<numeric>(x));
-	
+
 	return floor(x).hold();
 }
-static ex floor_evalf(const ex & x) 
-{ 
+static ex floor_evalf(const ex & x)
+{
 	if (is_exactly_a<numeric>(x))
 		return floor(ex_to<numeric>(x));
-	
-	return floor(x).hold();	
+
+	return floor(x).hold();
 }
-                                                                                
+
 static void floor_print_latex(const ex & arg1, const print_context & c)
 {
     c.s << "{"; arg1.print(c); c.s << "|}";
 }
-                                                                                
+
 static void floor_print_csrc_float(const ex & arg1, const print_context & c)
 {
     c.s << "std::floor("; arg1.print(c); c.s << ")";
@@ -231,20 +231,20 @@ REGISTER_FUNCTION(floor, eval_func( floor_eval).
                        print_func<print_csrc_float>( floor_print_csrc_float).
                        print_func<print_csrc_double>( floor_print_csrc_float));
 DECLARE_FUNCTION_1P(fract);
-static ex fract_eval(const ex & x) 
-{ 
+static ex fract_eval(const ex & x)
+{
 	if (is_exactly_a<numeric>(x))
 		return ex_to<numeric>(x)-floor(ex_to<numeric>(x));
-	
+
 	return fract(x).hold();
 }
 
-                                                                                
+
 static void fract_print_latex(const ex & arg1, const print_context & c)
 {
     c.s << "{"; arg1.print(c); c.s << "|}";
 }
-                                                                                
+
 static void fract_print_csrc_float(const ex & arg1, const print_context & c)
 {
     arg1.print(c); c.s << " - std::floor(";arg1.print(c); c.s << ")";
@@ -255,31 +255,31 @@ REGISTER_FUNCTION(fract, eval_func( fract_eval).
                        print_func<print_csrc_float>( fract_print_csrc_float).
                        print_func<print_csrc_double>( fract_print_csrc_float));
 DECLARE_FUNCTION_1P(ceil);
-static ex ceil_eval(const ex & x) 
-{ 
+static ex ceil_eval(const ex & x)
+{
 	if (is_exactly_a<numeric>(x))
 		return ceil(ex_to<numeric>(x));
-	
+
 	return ceil(x).hold();
 }
-static ex ceil_evalf(const ex & x) 
-{ 
+static ex ceil_evalf(const ex & x)
+{
 	if (is_exactly_a<numeric>(x))
 		return ceil(ex_to<numeric>(x));
-	
-	return ceil(x).hold();	
+
+	return ceil(x).hold();
 }
-                                                                                
+
 static void ceil_print_latex(const ex & arg1, const print_context & c)
 {
     c.s << "{"; arg1.print(c); c.s << "|}";
 }
-                                                                                
+
 static void ceil_print_csrc_float(const ex & arg1, const print_context & c)
 {
     c.s << "std::ceil("; arg1.print(c); c.s << ")";
 }
-                                                                                
+
 REGISTER_FUNCTION(ceil, eval_func( ceil_eval).
                        evalf_func( ceil_evalf).
                        print_func<print_latex>( ceil_print_latex).
@@ -287,31 +287,31 @@ REGISTER_FUNCTION(ceil, eval_func( ceil_eval).
                        print_func<print_csrc_double>( ceil_print_csrc_float));
 
 DECLARE_FUNCTION_1P(sign);
-static ex sign_eval(const ex & x) 
-{ 
+static ex sign_eval(const ex & x)
+{
 	if (is_exactly_a<numeric>(x))
 		return (numeric(0.) < ex_to<numeric>(x)) - (ex_to<numeric>(x) < numeric(0.));
-	
+
 	return sign(x).hold();
 }
-static ex sign_evalf(const ex & x) 
-{ 
+static ex sign_evalf(const ex & x)
+{
 	if (is_exactly_a<numeric>(x))
 		return (numeric(0.) < ex_to<numeric>(x)) - (ex_to<numeric>(x) < numeric(0.));
-	
-	return sign(x).hold();	
+
+	return sign(x).hold();
 }
-                                                                                
+
 static void sign_print_latex(const ex & arg1,const print_context & c)
 {
     c.s << "{"; arg1.print(c); c.s << "|}";
 }
-                                                                                
+
 static void sign_print_csrc_float(const ex & arg1, const print_context & c)
 {
-    c.s << "(double(0) < "; arg1.print(c); c.s << ")-(";arg1.print(c); c.s << " < double(0))"; 
+    c.s << "(double(0) < "; arg1.print(c); c.s << ")-(";arg1.print(c); c.s << " < double(0))";
 }
-                                                                                
+
 REGISTER_FUNCTION(sign, eval_func( sign_eval).
                        evalf_func( sign_evalf).
                        print_func<print_latex>( sign_print_latex).
@@ -319,27 +319,27 @@ REGISTER_FUNCTION(sign, eval_func( sign_eval).
                        print_func<print_csrc_double>( sign_print_csrc_float));
 
 DECLARE_FUNCTION_3P(clamp)
-static ex clamp_eval( const ex & x, const ex & lo, const ex& hi ) 
-{ 
+static ex clamp_eval( const ex & x, const ex & lo, const ex& hi )
+{
 	if (is_exactly_a<numeric>(x) && is_exactly_a<numeric>(lo) && is_exactly_a<numeric>(hi))
 	{
 		return std::clamp((ex_to<numeric>(x) - ex_to<numeric>(lo)) / (ex_to<numeric>(hi) - ex_to<numeric>(lo)), numeric(0.0), numeric(1.0));
 	}
-	
+
 	return clamp(x, lo, hi).hold();
 }
-                                                                                
+
 static void clamp_print_latex(const ex & x, const ex&  lo, const ex& hi,const print_context & c)
 {
     c.s << "{"; lo.print(c); c.s << "\%"; hi.print(c); c.s << "|}";
 }
 
-static void clamp_print_csrc_float(const ex & x, const ex&  lo, const ex& hi,const print_context & c)												                                
+static void clamp_print_csrc_float(const ex & x, const ex&  lo, const ex& hi,const print_context & c)
 {
  	c.s << "std::clamp( "; x.print(c); c.s << ", "; lo.print(c); c.s << ","; hi.print(c); c.s << ")";
 }
 
-                                                                                
+
 REGISTER_FUNCTION(clamp, eval_func(clamp_eval).
                        evalf_func(clamp_eval).
                        print_func<print_latex>(clamp_print_latex).
@@ -347,29 +347,29 @@ REGISTER_FUNCTION(clamp, eval_func(clamp_eval).
                        print_func<print_csrc_double>(clamp_print_csrc_float));
 
 DECLARE_FUNCTION_2P(step1);
-static ex step1_eval( const ex & x, const ex & edge ) 
-{ 
+static ex step1_eval( const ex & x, const ex & edge )
+{
 	if (is_exactly_a<numeric>(x) && is_exactly_a<numeric>(edge) )
 	{
 		if ( ex_to<numeric>(x) < ex_to<numeric>(edge) )
 			return 0.;
 		return 1;
 	}
-	
+
 	return step1(x, edge).hold();
 }
-                                                                                
+
 static void step1_print_latex(const ex & arg1, const ex&  arg2,const print_context & c)
 {
     c.s << "{ step1("; arg1.print(c); c.s << ","; arg2.print(c); c.s << ")}";
 }
-                                                                                
+
 static void step1_print_csrc_float(const ex & arg1, const ex & arg2, const print_context & c)
 {
     c.s << "("; arg1.print(c); c.s << " < "; arg2.print(c); c.s << ") ? 0. : 1.";
 }
 
-                                                                                
+
 REGISTER_FUNCTION(step1, eval_func(step1_eval).
                        evalf_func(step1_eval).
                        print_func<print_latex>(step1_print_latex).
@@ -377,31 +377,31 @@ REGISTER_FUNCTION(step1, eval_func(step1_eval).
                        print_func<print_csrc_double>(step1_print_csrc_float));
 
 DECLARE_FUNCTION_3P(smoothstep)
-static ex smoothstep_eval( const ex & x, const ex & lo, const ex& hi ) 
-{ 
+static ex smoothstep_eval( const ex & x, const ex & lo, const ex& hi )
+{
 	if (is_exactly_a<numeric>(x) && is_exactly_a<numeric>(lo) && is_exactly_a<numeric>(hi))
 	{
-		auto t = std::clamp((ex_to<numeric>(x) - ex_to<numeric>(lo)) / (ex_to<numeric>(hi) - ex_to<numeric>(lo)), numeric(0.0), numeric(1.0));
+		auto t = std::clamp((ex_to<numeric>(x) - (ex_to<numeric>(lo))) / (ex_to<numeric>(hi) - (ex_to<numeric>(lo))), numeric(0.0), numeric(1.0));
 		return t * t * (3.0 - 2.0 * t);;
 	}
-	
+
 	return smoothstep(x, lo, hi).hold();
 }
-                                                                                
+
 static void smoothstep_print_latex(const ex & x, const ex&  lo, const ex& hi,const print_context & c)
 {
     c.s << "{"; lo.print(c); c.s << "\%"; hi.print(c); c.s << "|}";
 }
 
-static void smoothstep_print_csrc_float(const ex & x, const ex&  lo, const ex& hi,const print_context & c)												                                
+static void smoothstep_print_csrc_float(const ex & x, const ex&  lo, const ex& hi,const print_context & c)
 {
- 	c.s << "[]( const double& t ){ return t * t * (3.0 - 2.0 * t); }( std::clamp( "; 
-	c.s << "("; x.print(c); c.s << "-"; lo.print(c); c.s << ")/"; 
-	c.s << "("; hi.print(c); c.s << "-"; lo.print(c); c.s << ")"; 
+ 	c.s << "[]( const double& t ){ return t * t * (3.0 - 2.0 * t); }( std::clamp( ";
+	c.s << "("; x.print(c); c.s << "-"; lo.print(c); c.s << ")/";
+	c.s << "("; hi.print(c); c.s << "-"; lo.print(c); c.s << ")";
 	c.s << ", 0.0, 1.0) )";
 }
 
-                                                                                
+
 REGISTER_FUNCTION(smoothstep, eval_func(smoothstep_eval).
                        evalf_func(smoothstep_eval).
                        print_func<print_latex>(smoothstep_print_latex).
@@ -410,8 +410,8 @@ REGISTER_FUNCTION(smoothstep, eval_func(smoothstep_eval).
 
 
 DECLARE_FUNCTION_3P(rectangle);
-static ex rectangle_eval( const ex & x, const ex & lo, const ex& hi ) 
-{ 
+static ex rectangle_eval( const ex & x, const ex & lo, const ex& hi )
+{
 	if (is_exactly_a<numeric>(x) && is_exactly_a<numeric>(lo) && is_exactly_a<numeric>(hi) )
 	{
 		if ( ex_to<numeric>(x) < ex_to<numeric>(lo) )
@@ -420,22 +420,22 @@ static ex rectangle_eval( const ex & x, const ex & lo, const ex& hi )
 			return 0.;
 		return 1;
 	}
-	
+
 	return rectangle(x, lo, hi).hold();
 }
-                                                                                
+
 static void rectangle_print_latex(const ex & arg1, const ex&  arg2,const ex&  arg3,const print_context & c)
 {
     c.s << "{ rectangle("; arg1.print(c); c.s << ","; arg2.print(c); c.s << ")}";
 }
-                                                                                
+
 static void rectangle_print_csrc_float(const ex & x, const ex & lo, const ex & hi, const print_context & c)
 {
     c.s << "(("; x.print(c); c.s << " < "; lo.print(c); c.s << ") ? 0. :";
 	c.s << "("; hi.print(c); c.s << " < "; x.print(c); c.s << ") ? 0. : 1.)";
 }
 
-                                                                                
+
 REGISTER_FUNCTION(rectangle, eval_func(rectangle_eval).
                        evalf_func(rectangle_eval).
                        print_func<print_latex>(rectangle_print_latex).
@@ -443,8 +443,8 @@ REGISTER_FUNCTION(rectangle, eval_func(rectangle_eval).
                        print_func<print_csrc_double>(rectangle_print_csrc_float));
 
 DECLARE_FUNCTION_3P(triangle);
-static ex triangle_eval( const ex & x, const ex & lo, const ex& hi ) 
-{ 
+static ex triangle_eval( const ex & x, const ex & lo, const ex& hi )
+{
 	if (is_exactly_a<numeric>(x) && is_exactly_a<numeric>(lo) && is_exactly_a<numeric>(hi) )
 	{
 		auto t = std::clamp( ( ex_to<numeric>(x)-ex_to<numeric>(lo))/(ex_to<numeric>(hi)-ex_to<numeric>(lo)), numeric(0), numeric(0) );
@@ -452,24 +452,24 @@ static ex triangle_eval( const ex & x, const ex & lo, const ex& hi )
 	}
 	return triangle(x, lo, hi).hold();
 }
-                                                                                
+
 static void triangle_print_latex(const ex & arg1, const ex&  arg2, const ex&  arg3,const print_context & c)
 {
     c.s << "{ triangle("; arg1.print(c); c.s << ","; arg2.print(c); c.s << ")}";
 }
-                                                                                
+
 static void triangle_print_csrc_float(const ex & x, const ex & lo, const ex & hi, const print_context & c)
 {
 	c.s << "1-std::abs(";
 	c.s << "std::clamp( ";
-	c.s << " -1 + 2*( "; x.print(c); c.s << "-"; lo.print(c); c.s << ")/"; 
-	c.s << "("; hi.print(c); c.s << "-"; lo.print(c); c.s << ")"; 
+	c.s << " -1 + 2*( "; x.print(c); c.s << "-"; lo.print(c); c.s << ")/";
+	c.s << "("; hi.print(c); c.s << "-"; lo.print(c); c.s << ")";
 	c.s << ", -1.0, 1.0)";
 	c.s << ")";
-	
+
 }
 
-                                                                                
+
 REGISTER_FUNCTION(triangle, eval_func(triangle_eval).
                        evalf_func(triangle_eval).
                        print_func<print_latex>(triangle_print_latex).
@@ -478,34 +478,34 @@ REGISTER_FUNCTION(triangle, eval_func(triangle_eval).
 
 
 DECLARE_FUNCTION_5P(mapabcd);
-static ex mapabcd_eval( const ex & x, const ex & a, const ex& b, const ex & c, const ex& d ) 
-{ 
+static ex mapabcd_eval( const ex & x, const ex & a, const ex& b, const ex & c, const ex& d )
+{
 	if (is_exactly_a<numeric>(x) && is_exactly_a<numeric>(a) && is_exactly_a<numeric>(b)&& is_exactly_a<numeric>(c) && is_exactly_a<numeric>(d) )
 	{
-		return std::clamp( ex_to<numeric>(c) + ( ex_to<numeric>(d)-ex_to<numeric>(c))*( ex_to<numeric>(x)-ex_to<numeric>(a))/(ex_to<numeric>(b)-ex_to<numeric>(a)), 
+		return std::clamp( ex_to<numeric>(c) + ( ex_to<numeric>(d)-ex_to<numeric>(c))*( ex_to<numeric>(x)-ex_to<numeric>(a))/(ex_to<numeric>(b)-ex_to<numeric>(a)),
 				     	   ex_to<numeric>(a), ex_to<numeric>(b) );
 	}
 	return mapabcd( x, a, b, c, d ).hold();
 }
-                                                                                
+
 static void mapabcd_print_latex(const ex & x, const ex & a, const ex& b, const ex & c, const ex& d, const print_context & co)
 {
     co.s << "{ mapabcd("; x.print(co); co.s << ","; a.print(co); co.s << ","; b.print(co);co.s << ","; c.print(co);co.s << ","; d.print(co);co.s << ")}";
 }
-                                                                                
+
 static void mapabcd_print_csrc_float(const ex & x, const ex & a, const ex & b, const ex & c, const ex & d, const print_context & co)
 {
 	co.s << "std::clamp( ";
-	c.print(co); co.s << "+ "; 
-	co.s << "("; d.print(co); co.s << "-("; c.print(co); co.s << "))"; 
-	co.s << "*( "; x.print(co); co.s << "-("; a.print(co); co.s << "))/"; 
-	co.s << "("; b.print(co); co.s << "-("; a.print(co); co.s << "))"; 
-	co.s << ","; c.print(co); co.s << ","; d.print(co); 
+	c.print(co); co.s << "+ ";
+	co.s << "("; d.print(co); co.s << "-("; c.print(co); co.s << "))";
+	co.s << "*( "; x.print(co); co.s << "-("; a.print(co); co.s << "))/";
+	co.s << "("; b.print(co); co.s << "-("; a.print(co); co.s << "))";
+	co.s << ","; c.print(co); co.s << ","; d.print(co);
 	co.s << ")";
-	
+
 }
 
-                                                                                
+
 REGISTER_FUNCTION(mapabcd, eval_func(mapabcd_eval).
                        evalf_func(mapabcd_eval).
                        print_func<print_latex>(mapabcd_print_latex).
@@ -514,8 +514,8 @@ REGISTER_FUNCTION(mapabcd, eval_func(mapabcd_eval).
 
 
 DECLARE_FUNCTION_4P(pulse);
-static ex pulse_eval( const ex & x, const ex & a, const ex& b, const ex & p ) 
-{ 
+static ex pulse_eval( const ex & x, const ex & a, const ex& b, const ex & p )
+{
 	if (is_exactly_a<numeric>(x) && is_exactly_a<numeric>(a) && is_exactly_a<numeric>(b)&& is_exactly_a<numeric>(p) )
 	{
 		if ( mod( ex_to<numeric>(x), ex_to<numeric>(p) ) < ex_to<numeric>(a) )
@@ -526,22 +526,22 @@ static ex pulse_eval( const ex & x, const ex & a, const ex& b, const ex & p )
 	}
 	return pulse( x, a, b, p ).hold();
 }
-                                                                                
+
 static void pulse_print_latex(const ex & x, const ex & a, const ex& b, const ex & p, const print_context & co)
 {
     co.s << "{ pulse("; x.print(co); co.s << ","; a.print(co); co.s << ","; b.print(co);co.s << ","; p.print(co); co.s << ")}";
 }
-                                                                                
+
 static void pulse_print_csrc_float(const ex & x, const ex & a, const ex & b, const ex & p, const print_context & co)
 {
 	co.s << "(( std::fmod("; x.print(co); co.s << ","; p.print(co); co.s << ") < "; a.print(co); co.s << ") ? 0. :";
-	co.s << "("; b.print(co); co.s << " < ";  co.s << "( std::fmod("; x.print(co); co.s << ","; p.print(co); co.s << ")"; co.s << ") ? 0. : 1.))";	
+	co.s << "("; b.print(co); co.s << " < ";  co.s << "( std::fmod("; x.print(co); co.s << ","; p.print(co); co.s << ")"; co.s << ") ? 0. : 1.))";
 }
 
 /**
  * @brief rectangle pulse of period @p
  * @return the ginac expression of the pulse
- */                                                                                
+ */
 REGISTER_FUNCTION(pulse, eval_func(pulse_eval).
                        evalf_func(pulse_eval).
                        print_func<print_latex>(pulse_print_latex).
@@ -549,20 +549,20 @@ REGISTER_FUNCTION(pulse, eval_func(pulse_eval).
                        print_func<print_csrc_double>(pulse_print_csrc_float));
 
 DECLARE_FUNCTION_3P(sinewave);
-static ex sinewave_eval( const ex & x, const ex & f, const ex & phi ) 
-{ 
+static ex sinewave_eval( const ex & x, const ex & f, const ex & phi )
+{
 	if (is_exactly_a<numeric>(x) && is_exactly_a<numeric>(f)&& is_exactly_a<numeric>(phi) )
 	{
 		return sin( 2*Pi*ex_to<numeric>(f)*ex_to<numeric>(x) + ex_to<numeric>(phi) );
 	}
 	return sinewave( x, f, phi ).hold();
 }
-                                                                                
+
 static void sinewave_print_latex(const ex & x, const ex & f, const ex & phi,  const print_context & co)
 {
     co.s << "{sin(2*pi*"; f.print(co); co.s << "*"; x.print(co); co.s << "+"; phi.print(co); co.s << ")}";
 }
-                                                                                
+
 static void sinewave_print_csrc_float(const ex & x, const ex & f, const ex & phi, const print_context & co)
 {
 	co.s << "("; co.s << "sin(2*pi*"; f.print(co); co.s << "*"; x.print(co); co.s << "+"; phi.print(co); co.s << "))";
@@ -571,13 +571,13 @@ static void sinewave_print_csrc_float(const ex & x, const ex & f, const ex & phi
 /**
  * @brief rectangle sinewave of period @p
  * @return the ginac expression of the sinewave
- */                                                                                
+ */
 REGISTER_FUNCTION(sinewave, eval_func(sinewave_eval).
                        evalf_func(sinewave_eval).
                        print_func<print_latex>(sinewave_print_latex).
                        print_func<print_csrc_float>(sinewave_print_csrc_float).
                        print_func<print_csrc_double>(sinewave_print_csrc_float));
-					   
+
 static ex mod_reader(const exvector& ev)
 {
 	return GiNaC::mod(ev[0],ev[1]);
@@ -645,7 +645,7 @@ const prototype_table& get_default_reader()
 	static bool initialized = false;
 	static prototype_table reader;
 	if (!initialized) {
-		
+
 		reader[make_pair("sqrt", 1)] = sqrt_reader;
 		reader[make_pair("pow", 2)] = pow_reader;
 		reader[make_pair("mod", 2)] = mod_reader;
@@ -670,7 +670,7 @@ const prototype_table& get_builtin_reader()
 	static bool initialized = false;
 	static prototype_table reader;
 	if (!initialized) {
-		
+
 		reader[make_pair("sqrt", 1)] = sqrt_reader;
 		reader[make_pair("pow", 2)] = pow_reader;
 		reader[make_pair("mod", 2)] = mod_reader;

--- a/feelpp/contrib/ginac/ginac/parser/default_reader.cpp
+++ b/feelpp/contrib/ginac/ginac/parser/default_reader.cpp
@@ -396,8 +396,8 @@ static void smoothstep_print_latex(const ex & x, const ex&  lo, const ex& hi,con
 static void smoothstep_print_csrc_float(const ex & x, const ex&  lo, const ex& hi,const print_context & c)
 {
  	c.s << "[]( const double& t ){ return t * t * (3.0 - 2.0 * t); }( std::clamp( ";
-	c.s << "("; x.print(c); c.s << "-"; lo.print(c); c.s << ")/";
-	c.s << "("; hi.print(c); c.s << "-"; lo.print(c); c.s << ")";
+	c.s << "("; x.print(c); c.s << "-("; lo.print(c); c.s << "))/";
+	c.s << "("; hi.print(c); c.s << "-("; lo.print(c); c.s << "))";
 	c.s << ", 0.0, 1.0) )";
 }
 
@@ -462,8 +462,8 @@ static void triangle_print_csrc_float(const ex & x, const ex & lo, const ex & hi
 {
 	c.s << "1-std::abs(";
 	c.s << "std::clamp( ";
-	c.s << " -1 + 2*( "; x.print(c); c.s << "-"; lo.print(c); c.s << ")/";
-	c.s << "("; hi.print(c); c.s << "-"; lo.print(c); c.s << ")";
+	c.s << " -1 + 2*( "; x.print(c); c.s << "-("; lo.print(c); c.s << "))/";
+	c.s << "("; hi.print(c); c.s << "-("; lo.print(c); c.s << "))";
 	c.s << ", -1.0, 1.0)";
 	c.s << ")";
 

--- a/python/pyfeelpp/feelpp/vf.cpp
+++ b/python/pyfeelpp/feelpp/vf.cpp
@@ -81,7 +81,6 @@ void addGinacMatrix( py::module& m )
                 return y; },
             "evaluate the expression for an array of values for one parameter", py::arg( "parameter" ), py::arg( "values" ), py::arg( "parallel" ) = true )
         .def(
-            // "evaluate", []( Expr<GinacMatrix<M, N, Order>>& e, std::vector<std::string> const& s_vct, std::vector<Eigen::VectorXd> const& x_vct, bool parallel )
             "evaluate", []( Expr<GinacMatrix<M, N, Order>>& e, std::map<std::string, Eigen::VectorXd> const& m, bool parallel )
             {
                 std::cout << "evaluate with map" << std::endl;
@@ -104,7 +103,7 @@ void addGinacMatrix( py::module& m )
                 }
                 return y;
             },
-            "evaluate the expression", py::arg( "mp" ), py::arg( "parallel" ) = true )
+            "evaluate the expression for arrays of parameters", py::arg( "mp" ), py::arg( "parallel" ) = true )
         .def(
             "diff", []( Expr<GinacMatrix<M, N, Order>>& e, std::string const& s )
             { return e.template diff<1>( s ); },

--- a/python/pyfeelpp/feelpp/vf.cpp
+++ b/python/pyfeelpp/feelpp/vf.cpp
@@ -83,7 +83,6 @@ void addGinacMatrix( py::module& m )
         .def(
             "evaluate", []( Expr<GinacMatrix<M, N, Order>>& e, std::map<std::string, Eigen::VectorXd> const& m, bool parallel )
             {
-                std::cout << "evaluate with map" << std::endl;
                 if (m.empty())
                     throw std::runtime_error("[expr:evaluate] map is empty");
 

--- a/python/pyfeelpp/feelpp/vf.cpp
+++ b/python/pyfeelpp/feelpp/vf.cpp
@@ -42,7 +42,7 @@ using namespace Feel;
 void defExpr(py::module &m)
 {
     using namespace Feel;
- 
+
 }
 
 template<int M, int N, int Order>
@@ -68,18 +68,43 @@ void addGinacMatrix( py::module& m )
         .def(
             "evaluate", []( Expr<GinacMatrix<M, N, Order>>& e, std::map<std::string, double /*value_type*/> const& m )
             { return e.evaluate( m ); },
-            "evaluate the expression", py::arg( "mp" ) )
+            "evaluate the expression for a given dict of values", py::arg( "mp" ) )
         .def(
             "evaluate", []( Expr<GinacMatrix<M, N, Order>>& e, std::string const& s, Eigen::VectorXd const& x, bool parallel )
             {
                 Eigen::VectorXd y(x.size());
-                std::transform( x.begin(), x.end(),  y.begin(), 
-                                  [&e,s,parallel](auto x) { 
+                std::transform( x.begin(), x.end(),  y.begin(),
+                                  [&e,s,parallel](auto x) {
                                       e.setParameterValues( { { s, x } } );
-                                      return e.evaluate(parallel)( 0, 0 ); 
+                                      return e.evaluate(parallel)( 0, 0 );
                                   } );
                 return y; },
-            "evaluate the expression", py::arg( "parameter" ), py::arg( "values" ), py::arg( "parallel" ) = true )
+            "evaluate the expression for an array of values for one parameter", py::arg( "parameter" ), py::arg( "values" ), py::arg( "parallel" ) = true )
+        .def(
+            // "evaluate", []( Expr<GinacMatrix<M, N, Order>>& e, std::vector<std::string> const& s_vct, std::vector<Eigen::VectorXd> const& x_vct, bool parallel )
+            "evaluate", []( Expr<GinacMatrix<M, N, Order>>& e, std::map<std::string, Eigen::VectorXd> const& m, bool parallel )
+            {
+                std::cout << "evaluate with map" << std::endl;
+                if (m.empty())
+                    throw std::runtime_error("[expr:evaluate] map is empty");
+
+                size_t n = m.begin()->second.size();
+                for (const auto& [key, values] : m)
+                {
+                    if (values.size() != n)
+                        throw std::runtime_error("[expr:evaluate] size mismatch in parameter arrays");
+                }
+
+                Eigen::VectorXd y(n);
+                for (size_t i = 0; i < n; ++i)
+                {
+                    for (const auto& [key, values] : m)
+                        e.setParameterValues({{key, values[i]}});
+                    y(i) = e.evaluate(parallel)(0, 0);
+                }
+                return y;
+            },
+            "evaluate the expression", py::arg( "mp" ), py::arg( "parallel" ) = true )
         .def(
             "diff", []( Expr<GinacMatrix<M, N, Order>>& e, std::string const& s )
             { return e.template diff<1>( s ); },
@@ -123,7 +148,7 @@ PYBIND11_MODULE(_vf, m )
                             constexpr int _order = std::decay_t<decltype(hana::at_c<1>(d))>::value;
                             using mesh_t = Mesh<Simplex<_dim, 1>>;
                             using mesh_ptr_t = std::shared_ptr<mesh_t>;
-                            
+
                             m.def( "vonmises", []( Pchv_element_t<mesh_t, 1> const& d, nl::json const& model )
                                    {
                                         auto Xh = Pch<_order>(d.functionSpace()->mesh());
@@ -137,7 +162,7 @@ PYBIND11_MODULE(_vf, m )
                                             r.on( _range=elements(d.functionSpace()->mesh()), _expr=vonmises( 2*mu*def+lambda*divv(d)*eye<_dim,_dim>() ) );
                                         }
 
-                                        return r; 
+                                        return r;
                                     },
                                     "compute von mises stress", py::arg( "displacement" ), py::arg( "model" ) );
                         } );

--- a/testsuite/feelvf/test_ginac.cpp
+++ b/testsuite/feelvf/test_ginac.cpp
@@ -206,7 +206,7 @@ void runTest0()
     std::cout << std::flush;
 
     //not working because ex is not mutable
-    //boost::for_each(exact_parsed, [](GiNaC::ex const& e) 
+    //boost::for_each(exact_parsed, [](GiNaC::ex const& e)
     //{
     //if (GiNaC::is_a<symbol>(e)) std::cout << "Found Symbol : " <<  GiNaC::ex_to<symbol>(e).get_name() << "\n";
     //});
@@ -942,6 +942,30 @@ BOOST_AUTO_TEST_CASE( test_triangle )
     BOOST_CHECK_CLOSE( a1b.evaluate()(0,0), 0.5, 1e-12 );
 }
 
+BOOST_AUTO_TEST_CASE( test_triangle_neg )
+{
+    auto a1b = expr("triangle(t,-1,2):t");
+    std::vector<std::pair<double, double>> testCases = {
+        { -2, 0 },
+        { 3, 0 },
+        { 0.5, 1 },
+        { 1.5, 1./3 },
+        { 1, 2./3 },
+        { 2, 0 },
+        { 1.75, 1./6 },
+        { 1.25, 0.5 }
+    };
+
+    for (const auto& [t, expected] : testCases) {
+        a1b.setParameterValues( { { "t", t } } );
+        if (expected == 0) {
+            BOOST_CHECK_SMALL(a1b.evaluate()(0, 0), 1e-12);
+        } else {
+            BOOST_CHECK_CLOSE(a1b.evaluate()(0, 0), expected, 1e-12);
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE( test_mapabcd )
 {
     auto a1b = expr("mapabcd(t,1,2,-1,1):t");
@@ -960,4 +984,54 @@ BOOST_AUTO_TEST_CASE( test_mapabcd )
     a1b.setParameterValues( { { "t", 1.75 } } );
     BOOST_CHECK_CLOSE( a1b.evaluate()(0,0), 0.5, 1e-12 );
 }
+
+BOOST_AUTO_TEST_CASE( test_smoothstep )
+{
+    auto a1b = expr("smoothstep(t,0,2):t");
+    std::vector<std::pair<double, double>> testCases = {
+        { -2, 0 },
+        { 3, 1 },
+        { 0.5, 0.15625 },
+        { 1.5, 0.84375 },
+        { 1, 0.5 },
+        { 2, 1 },
+        { 1.75, 0.95703125 },
+        { 1.25, 0.68359375 }
+    };
+
+    for (const auto& [t, expected] : testCases) {
+        a1b.setParameterValues( { { "t", t } } );
+        if (expected == 0) {
+            BOOST_CHECK_SMALL(a1b.evaluate()(0, 0), 1e-12);
+        } else {
+            BOOST_CHECK_CLOSE(a1b.evaluate()(0, 0), expected, 1e-12);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE( test_smoothstep_neg )
+{
+    auto a1b = expr("smoothstep(t,-1,2):t");
+    std::vector<std::pair<double, double>> testCases = {
+        { -2, 0 },
+        { 3, 1 },
+        { 0.5, 0.5 },
+        { 1.5, 0.9259259259 },
+        { 1, 0.7407407407 },
+        { 2, 1 },
+        { 1.75, 0.9803240741 },
+        { 1.25, 0.84375 }
+    };
+
+    for (const auto& [t, expected] : testCases) {
+        a1b.setParameterValues( { { "t", t } } );
+        if (expected == 0) {
+            BOOST_CHECK_SMALL(a1b.evaluate()(0, 0), 1e-8);
+        } else {
+            BOOST_CHECK_CLOSE(a1b.evaluate()(0, 0), expected, 1e-8);
+        }
+    }
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/feelpp/feelpp/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes?
- [x] Have you successfully run the Feel++ testsuite with your changes locally?
- [x] Have you written Doxygen comments in your contribution ?

-----

- Close #2341 The fix has been done for `smoothstep` and `triangle`
- Bonus: I added a new prototype to the function `evaluate` for expressions in Python, allowing to perform that kind of computation:

```py
ex = fppc.expr("x+y:x:y")
x = [1,2,3]
y = [4,5,6]
z = ex.evaluate({"x": x, "y": y})
```
(Previously, it wasn't possible to evaluate expression with many arrays like that)